### PR TITLE
Update bitvec to 1.0.0

### DIFF
--- a/ssz_rs/Cargo.toml
+++ b/ssz_rs/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
 
 [dependencies]
 thiserror = "1.0.25"
-bitvec = "0.22.3"
+bitvec = "1.0.0"
 ssz_rs_derive = { path = "../ssz_rs_derive", version = "0.7.0" }
 sha2 = "0.9.8"
 lazy_static = "1.4.0"

--- a/ssz_rs/src/bitlist.rs
+++ b/ssz_rs/src/bitlist.rs
@@ -9,7 +9,7 @@ use std::fmt;
 use std::iter::FromIterator;
 use std::ops::{Deref, DerefMut};
 
-type BitlistInner = BitVec<Lsb0, u8>;
+type BitlistInner = BitVec<u8, Lsb0>;
 
 /// A homogenous collection of a variable number of boolean values.
 #[derive(PartialEq, Eq, Clone)]
@@ -132,7 +132,7 @@ impl<const N: usize> Deserialize for Bitlist<N> {
         }
 
         let (last_byte, prefix) = encoding.split_last().unwrap();
-        let mut result = BitlistInner::from_slice(prefix).expect("can read slice");
+        let mut result = BitlistInner::from_slice(prefix);
         let last = BitlistInner::from_element(*last_byte);
         let high_bit_index = 8 - last.trailing_zeros();
 

--- a/ssz_rs/src/bitvector.rs
+++ b/ssz_rs/src/bitvector.rs
@@ -8,7 +8,7 @@ use std::fmt;
 use std::iter::FromIterator;
 use std::ops::{Deref, DerefMut};
 
-type BitvectorInner = BitVec<Lsb0, u8>;
+type BitvectorInner = BitVec<u8, Lsb0>;
 
 /// A homogenous collection of a fixed number of boolean values.
 ///

--- a/ssz_rs/src/merkleization/cache.rs
+++ b/ssz_rs/src/merkleization/cache.rs
@@ -1,5 +1,5 @@
 use crate::merkleization::Node;
-use bitvec::prelude::{bitvec, BitVec};
+use bitvec::prelude::{bitvec, BitVec, Lsb0};
 
 #[derive(Default, Debug, Clone)]
 pub struct Cache {
@@ -12,7 +12,7 @@ impl Cache {
     pub fn with_leaves(leaf_count: usize) -> Self {
         Self {
             leaf_count,
-            dirty_leaves: bitvec![1; leaf_count],
+            dirty_leaves: bitvec![1,],
             ..Default::default()
         }
     }

--- a/ssz_rs/src/merkleization/cache.rs
+++ b/ssz_rs/src/merkleization/cache.rs
@@ -1,5 +1,5 @@
 use crate::merkleization::Node;
-use bitvec::prelude::{bitvec, BitVec, Lsb0};
+use bitvec::prelude::{BitVec};
 
 #[derive(Default, Debug, Clone)]
 pub struct Cache {
@@ -10,9 +10,22 @@ pub struct Cache {
 
 impl Cache {
     pub fn with_leaves(leaf_count: usize) -> Self {
+        // ensure dirty_leaves is length of leaf_count
+        // and initialized to ones
+        let mut dirty_leaves = BitVec::new();
+        for _i in 0..leaf_count {
+            dirty_leaves.push(true);
+        }
+        // quick checks (panic if not equal)
+        // 1) is length ok?
+        // 2) all elems == 1?
+        assert_eq!(dirty_leaves.len(), leaf_count);
+        assert_eq!(leaf_count, dirty_leaves.count_ones());
+
+        // pass dirty_leaves to Self, return Self
         Self {
             leaf_count,
-            dirty_leaves: bitvec![1,],
+            dirty_leaves,
             ..Default::default()
         }
     }


### PR DESCRIPTION
PR updates BitVec version to 1.0.0 and fixes bugs arising from this change.

All tests pass.

