### PR TITLE
feat(`uint`): widen accepted range of types on `try_from_bytes_le`

### DIFF
--- a/ssz-rs/src/uint.rs
+++ b/ssz-rs/src/uint.rs
@@ -78,8 +78,8 @@ impl U256 {
         Self::default()
     }
 
-    pub fn try_from_bytes_le(bytes: &[u8]) -> Result<Self, DeserializeError> {
-        Self::deserialize(bytes)
+    pub fn try_from_bytes_le(bytes: impl AsRef<[u8]>) -> Result<Self, DeserializeError> {
+        Self::deserialize(bytes.as_ref())
     }
 
     pub fn from_bytes_le(bytes: [u8; 32]) -> Self {


### PR DESCRIPTION
(Feel free to close this PR if the change is not wanted/needed—I know there's no issue associated to this)

Was just tinkering with the crate for a project, and saw that the type definition for `bytes` could be widened a bit so it can also accepted full vectors rather than just slices.