### PR TITLE
docs: add examples and crate docs

### DIFF
--- a/ssz-rs/src/de.rs
+++ b/ssz-rs/src/de.rs
@@ -5,12 +5,23 @@ use crate::{
     SimpleSerialize,
 };
 
+/// Deserialization errors.
 #[derive(Debug)]
 pub enum DeserializeError {
-    ExpectedFurtherInput { provided: usize, expected: usize },
-    AdditionalInput { provided: usize, expected: usize },
+    /// More data was expected to be in the buffer.
+    ExpectedFurtherInput {
+        provided: usize,
+        expected: usize,
+    },
+    /// The buffer contained more data than expected.
+    AdditionalInput {
+        provided: usize,
+        expected: usize,
+    },
     InvalidByte(u8),
+    /// An invalid instance was encountered.
     InvalidInstance(InstanceError),
+    /// An invalid type was encountered.
     InvalidType(TypeError),
 }
 
@@ -44,7 +55,9 @@ impl Display for DeserializeError {
 #[cfg(feature = "std")]
 impl std::error::Error for DeserializeError {}
 
+/// A data structure that can be deserialized using SSZ.
 pub trait Deserialize {
+    /// Deserialize this value from the given SSZ-encoded buffer.
     fn deserialize(encoding: &[u8]) -> Result<Self, DeserializeError>
     where
         Self: Sized;

--- a/ssz-rs/src/error.rs
+++ b/ssz-rs/src/error.rs
@@ -9,7 +9,9 @@ pub enum Error {
     Deserialize(DeserializeError),
     /// A merkleization error.
     Merkleization(MerkleizationError),
+    /// An invalid value.
     Instance(InstanceError),
+    /// An invalid type.
     Type(TypeError),
 }
 
@@ -46,9 +48,10 @@ impl Display for Error {
 #[cfg(feature = "std")]
 impl std::error::Error for Error {}
 
+/// An invalid type.
 #[derive(Debug)]
 pub enum TypeError {
-    /// A type is invalid within the given bounds.
+    /// A type is invalid for the given bounds.
     InvalidBound(usize),
 }
 
@@ -65,7 +68,7 @@ impl Display for TypeError {
 #[cfg(feature = "std")]
 impl std::error::Error for TypeError {}
 
-/// Instance errors.
+/// An invalid value.
 #[derive(Debug)]
 pub enum InstanceError {
     /// The number of elements did not match (`provided != required`)

--- a/ssz-rs/src/error.rs
+++ b/ssz-rs/src/error.rs
@@ -1,10 +1,13 @@
 use crate::{de::DeserializeError, lib::*, merkleization::MerkleizationError, ser::SerializeError};
 
-// Top-level error to wrap all child errors in crate
+/// Top-level error to wrap all other errors in this crate
 #[derive(Debug)]
 pub enum Error {
+    /// A serialization error.
     Serialize(SerializeError),
+    /// A deserialization error.
     Deserialize(DeserializeError),
+    /// A merkleization error.
     Merkleization(MerkleizationError),
     Instance(InstanceError),
     Type(TypeError),
@@ -45,6 +48,7 @@ impl std::error::Error for Error {}
 
 #[derive(Debug)]
 pub enum TypeError {
+    /// A type is invalid within the given bounds.
     InvalidBound(usize),
 }
 
@@ -61,9 +65,12 @@ impl Display for TypeError {
 #[cfg(feature = "std")]
 impl std::error::Error for TypeError {}
 
+/// Instance errors.
 #[derive(Debug)]
 pub enum InstanceError {
+    /// The number of elements did not match (`provided != required`)
     Exact { required: usize, provided: usize },
+    /// The number of elements exceeded the maximum expected amount (`provided > bound`)
     Bounded { bound: usize, provided: usize },
 }
 

--- a/ssz-rs/src/lib.rs
+++ b/ssz-rs/src/lib.rs
@@ -1,3 +1,35 @@
+//! An implementation of the [SSZ][ssz] serialization scheme.
+//!
+//! # Examples
+//!
+//! De/serialize a simple value:
+//!
+//! ```
+//! # use ssz_rs::prelude::*;
+//! let mut buf = Vec::new();
+//! 42u64.serialize(&mut buf);
+//! assert_eq!(u64::deserialize(&buf).unwrap(), 42);
+//! ```
+//!
+//! De/serialize a custom type using the derive macro:
+//!
+//! ```
+//! # use ssz_rs::prelude::*;
+//! #[derive(Debug, Default, Eq, PartialEq, SimpleSerialize)]
+//! struct Data {
+//!   flag: bool,
+//!   value: u64
+//! }
+//!
+//! let mut buf = Vec::new();
+//! Data { flag: true, value: 42 }.serialize(&mut buf);
+//! assert_eq!(
+//!   Data::deserialize(&buf).unwrap(),
+//!   Data { flag: true, value: 42 }
+//! );
+//! ```
+//!
+//! [ssz]: https://github.com/ethereum/consensus-specs/blob/dev/ssz/simple-serialize.md
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(not(feature = "std"))]

--- a/ssz-rs/src/merkleization/mod.rs
+++ b/ssz-rs/src/merkleization/mod.rs
@@ -15,7 +15,7 @@ pub use proofs::is_valid_merkle_branch;
 pub(crate) const BYTES_PER_CHUNK: usize = 32;
 
 pub trait Merkleized {
-    // Compute the "hash tree root" of `Self`.
+    /// Compute the "hash tree root" of `Self`.
     fn hash_tree_root(&mut self) -> Result<Node, MerkleizationError>;
 }
 
@@ -92,14 +92,17 @@ impl Index<usize> for Context {
 // Grab the precomputed context from the build stage
 include!(concat!(env!("OUT_DIR"), "/context.rs"));
 
-// Return the root of the Merklization of a binary tree formed from `chunks`.
-// `chunks` forms the bottom layer of a binary tree that is Merkleized.
-// This implementation is memory efficient by relying on pre-computed subtrees of all
-// "zero" leaves stored in the `CONTEXT`. SSZ specifies that `chunks` is padded to the next power
-// of two and this can be quite large for some types. "Zero" subtrees are virtualized to avoid the
-// memory and computation cost of large trees with partially empty leaves.
-// Invariant: `chunks.len() % BYTES_PER_CHUNK == 0`
-// Invariant: `leaf_count.next_power_of_two() == leaf_count`
+/// Return the root of the Merklization of a binary tree formed from `chunks`.
+///
+/// `chunks` forms the bottom layer of a binary tree that is Merkleized.
+///
+/// This implementation is memory efficient by relying on pre-computed subtrees of all
+/// "zero" leaves stored in the `CONTEXT`. SSZ specifies that `chunks` is padded to the next power
+/// of two and this can be quite large for some types. "Zero" subtrees are virtualized to avoid the
+/// memory and computation cost of large trees with partially empty leaves.
+///
+/// Invariant: `chunks.len() % BYTES_PER_CHUNK == 0`
+/// Invariant: `leaf_count.next_power_of_two() == leaf_count`
 fn merkleize_chunks_with_virtual_padding(
     chunks: &[u8],
     leaf_count: usize,

--- a/ssz-rs/src/merkleization/node.rs
+++ b/ssz-rs/src/merkleization/node.rs
@@ -1,5 +1,6 @@
 use crate::{lib::*, prelude::*, utils::write_bytes_to_lower_hex};
 
+/// A node in a merkle tree.
 #[derive(Default, Clone, Copy, Eq, SimpleSerialize)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Node(#[cfg_attr(feature = "serde", serde(with = "crate::serde::as_hex"))] [u8; 32]);

--- a/ssz-rs/src/ser.rs
+++ b/ssz-rs/src/ser.rs
@@ -8,10 +8,14 @@ use crate::{
 pub const BYTES_PER_LENGTH_OFFSET: usize = 4;
 const MAXIMUM_LENGTH: u64 = 2u64.pow((8 * BYTES_PER_LENGTH_OFFSET) as u32);
 
+/// Serialization errors.
 #[derive(Debug)]
 pub enum SerializeError {
+    /// The encoded length exceeds the maximum.
     MaximumEncodedLengthExceeded(usize),
+    /// An invalid instance was encountered.
     InvalidInstance(InstanceError),
+    /// An invalid type was encountered.
     InvalidType(TypeError),
 }
 
@@ -43,9 +47,11 @@ impl Display for SerializeError {
 #[cfg(feature = "std")]
 impl std::error::Error for SerializeError {}
 
+/// A data structure that can be serialized using SSZ.
 pub trait Serialize {
     /// Append an encoding of `self` to the `buffer`.
-    /// Return the number of bytes written.
+    ///
+    /// Returns the number of bytes written.
     fn serialize(&self, buffer: &mut Vec<u8>) -> Result<usize, SerializeError>;
 }
 


### PR DESCRIPTION
Adds some missing docs and some examples in the top-level module documentation. I am not entirely sure on what an "instance" is, so I did not explain much in the docs for that - is it a value?