### PR TITLE
Make `no_std` build work with `serde` feature enabled

### DIFF
--- a/ssz-rs/Cargo.toml
+++ b/ssz-rs/Cargo.toml
@@ -27,8 +27,8 @@ bitvec = { version = "1.0.0", default-features = false, features = ["alloc"] }
 ssz_rs_derive = { path = "../ssz-rs-derive", version = "0.8.0" }
 sha2 = { version ="0.9.8", default-features = false}
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"], optional = true }
-hex = {version = "0.4.3", default-features = false, features = ["alloc"], optional = true }
-num-bigint = { version ="0.4.3", default-features = false }
+hex = { version = "0.4.3", default-features = false, features = ["alloc"], optional = true }
+num-bigint = { version = "0.4.3", default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.3.3"

--- a/ssz-rs/Cargo.toml
+++ b/ssz-rs/Cargo.toml
@@ -23,13 +23,12 @@ std = [
 serde = ["dep:serde", "dep:hex"]
 
 [dependencies]
-thiserror = "1.0.25"
 bitvec = { version = "1.0.0", default-features = false, features = ["alloc"] }
 ssz_rs_derive = { path = "../ssz-rs-derive", version = "0.8.0" }
 sha2 = { version ="0.9.8", default-features = false}
-serde = { version = "1.0", features = ["derive"], optional = true }
-hex = { version = "0.4.3", optional = true }
-num-bigint = { version = "0.4.3", default-features = false }
+serde = { version = "1.0", default-features = false, features = ["alloc", "derive"], optional = true }
+hex = {version = "0.4.3", default-features = false, features = ["alloc"], optional = true }
+num-bigint = { version ="0.4.3", default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.3.3"

--- a/ssz-rs/src/lib.rs
+++ b/ssz-rs/src/lib.rs
@@ -73,7 +73,7 @@ mod lib {
         pub use std::*;
     }
 
-    pub use self::core::{any, cmp, fmt, iter, slice};
+    pub use self::core::{any, cmp, fmt, iter, marker::PhantomData, slice};
 
     pub use self::{
         cmp::Ordering,

--- a/ssz-rs/src/lib.rs
+++ b/ssz-rs/src/lib.rs
@@ -73,7 +73,7 @@ mod lib {
         pub use std::*;
     }
 
-    pub use self::core::{any, cmp, fmt, iter, marker::PhantomData, slice};
+    pub use self::core::{any, cmp, fmt, iter, slice};
 
     pub use self::{
         cmp::Ordering,
@@ -91,6 +91,9 @@ mod lib {
 
     #[cfg(feature = "std")]
     pub use std::vec::Vec;
+
+    #[cfg(feature = "serde")]
+    pub use self::core::marker::PhantomData;
 }
 
 /// `Sized` is a trait for types that can

--- a/ssz-rs/src/list.rs
+++ b/ssz-rs/src/list.rs
@@ -10,8 +10,6 @@ use crate::{
 };
 #[cfg(feature = "serde")]
 use serde::ser::SerializeSeq;
-#[cfg(feature = "serde")]
-use std::marker::PhantomData;
 
 /// A homogenous collection of a variable number of values.
 #[derive(Clone)]

--- a/ssz-rs/src/serde.rs
+++ b/ssz-rs/src/serde.rs
@@ -1,15 +1,33 @@
+use crate::lib::*;
 use hex::FromHexError;
-use thiserror::Error;
 
 const HEX_ENCODING_PREFIX: &str = "0x";
 
-#[derive(Debug, Error)]
+#[derive(Debug)]
 pub enum HexError {
-    #[error("{0}")]
-    Hex(#[from] FromHexError),
-    #[error("missing prefix `{HEX_ENCODING_PREFIX}` when deserializing hex data")]
+    Hex(FromHexError),
     MissingPrefix,
 }
+
+impl fmt::Display for HexError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Hex(e) => write!(f, "{e}"),
+            Self::MissingPrefix => {
+                write!(f, "missing prefix `{HEX_ENCODING_PREFIX}` when deserializing hex data")
+            }
+        }
+    }
+}
+
+impl From<FromHexError> for HexError {
+    fn from(e: FromHexError) -> Self {
+        Self::Hex(e)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for HexError {}
 
 fn try_bytes_from_hex_str(s: &str) -> Result<Vec<u8>, HexError> {
     let target = s.strip_prefix(HEX_ENCODING_PREFIX).ok_or(HexError::MissingPrefix)?;

--- a/ssz-rs/src/vector.rs
+++ b/ssz-rs/src/vector.rs
@@ -8,8 +8,6 @@ use crate::{
 };
 #[cfg(feature = "serde")]
 use serde::ser::SerializeSeq;
-#[cfg(feature = "serde")]
-use std::marker::PhantomData;
 
 /// A homogenous collection of a fixed number of values.
 /// NOTE: a `Vector` of length `0` is illegal.


### PR DESCRIPTION
when `serde` feature is enabled in a `no_std` build, it fails due to the references to `std`. This PR makes `serde` feature compatible with `no_std`.

Note that `thiserror` is completely removed because it doesn't support `no_std`.