### PR TITLE
Ignore ssz-rs-derive & ssz-rs-test-gen for coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+ignore:
+  - "ssz-rs-derive/**/*"
+  - "ssz-rs-test-gen/**/*"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,6 @@
 ignore:
   - "ssz-rs-derive/**/*"
   - "ssz-rs-test-gen/**/*"
+
+# When modifying this file, please validate using
+# curl -X POST --data-binary @codecov.yml https://codecov.io/validate


### PR DESCRIPTION
Looks like coverage is [over 70% for `ssz-rs`](https://app.codecov.io/gh/ralexstokes/ssz-rs) (see the per-directory breakdown at the bottom of the page), so ignoring these directories will give us a clearer picture of coverage in PRs & the CodeCov UI.

@ralexstokes This will override the [global yaml](https://docs.codecov.com/docs/codecov-yaml#global-yaml), but only for the keys mentioned in `codecov.yml`.