### PR TITLE
Enables overflow checks on all packages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,6 @@ members = [
     "ssz-rs-derive",
     "ssz-rs-test-gen"
 ]
+
+[profile.release]
+overflow-checks = true

--- a/ssz-rs-derive/Cargo.toml
+++ b/ssz-rs-derive/Cargo.toml
@@ -16,3 +16,6 @@ proc-macro = true
 syn = "1.0"
 quote = "1.0"
 proc-macro2 = "1.0"
+
+[profile.release]
+overflow-checks = true

--- a/ssz-rs-test-gen/Cargo.toml
+++ b/ssz-rs-test-gen/Cargo.toml
@@ -13,3 +13,6 @@ serde_yaml = "0.9"
 num-bigint = "0.4.3"
 hex = "0.4.3"
 convert_case = "0.6.0"
+
+[profile.release]
+overflow-checks = true

--- a/ssz-rs/Cargo.toml
+++ b/ssz-rs/Cargo.toml
@@ -39,3 +39,6 @@ serde_json = "1.0.81"
 
 [build-dependencies]
 sha2 = "0.9.8"
+
+[profile.release]
+overflow-checks = true


### PR DESCRIPTION
As recommended by audit:

> We recommend enabling overflow checks in all packages, including those that do not
currently perform calculations, to prevent unintended consequences if changes are added in
future releases or during refactoring. Note that enabling overflow checks in packages other
than the workspace manifest will lead to compiler warnings.