### PR TITLE
Replaces debug_assert_eq with size check errors

### DIFF
--- a/ssz-rs/src/ser.rs
+++ b/ssz-rs/src/ser.rs
@@ -42,7 +42,9 @@ impl Display for SerializeError {
             ),
             SerializeError::InvalidInstance(err) => write!(f, "invalid instance: {err}"),
             SerializeError::InvalidType(err) => write!(f, "invalid type: {err}"),
-            SerializeError::UnexpectedSize(size1, size2) => write!(f, "unexpected size: {size1} not equal to {size2}"),
+            SerializeError::UnexpectedSize(size1, size2) => {
+                write!(f, "unexpected size: {size1} not equal to {size2}")
+            }
         }
     }
 }

--- a/ssz-rs/src/ser.rs
+++ b/ssz-rs/src/ser.rs
@@ -131,3 +131,23 @@ pub fn serialize_composite<T: SimpleSerialize>(
         buffer,
     )
 }
+
+#[cfg(test)]
+mod test {
+    use crate::{ser::serialize_composite_from_components, SerializeError};
+
+    #[test]
+    fn invalid_serialize_composite_from_components() {
+        let fixed = vec![Some(vec![0, 8]), None];
+        let mut buffer = Vec::new();
+        let res = serialize_composite_from_components(fixed, vec![], vec![], 1, &mut buffer);
+
+        assert!(res.is_err());
+        if let SerializeError::UnexpectedSize(size1, size2) = res.unwrap_err() {
+            assert_eq!(size1, 2);
+            assert_eq!(size2, 0);
+        } else {
+            panic!("Not an UnexpectedSize error.");
+        }
+    }
+}


### PR DESCRIPTION
From audit: 

> We recommend implementing mentioned checks with an error handling logic in order to
perform them also in production code.