### PR TITLE
harden typing to increase safety of serialization routine

### DIFF
--- a/ssz-rs/src/array.rs
+++ b/ssz-rs/src/array.rs
@@ -8,7 +8,7 @@ use crate::{
     error::{InstanceError, TypeError},
     lib::*,
     merkleization::{elements_to_chunks, merkleize, pack, MerkleizationError, Merkleized, Node},
-    ser::{serialize_composite, Serialize, SerializeError},
+    ser::{Serialize, SerializeError, Serializer},
     SimpleSerialize, Sized,
 };
 
@@ -35,7 +35,11 @@ macro_rules! define_ssz_for_array_of_size {
                 if $n == 0 {
                     return Err(TypeError::InvalidBound($n).into())
                 }
-                serialize_composite(self, buffer)
+                let mut serializer = Serializer::default();
+                for element in self {
+                    serializer.with_element(element)?;
+                }
+                serializer.serialize(buffer)
             }
         }
 

--- a/ssz-rs/src/lib.rs
+++ b/ssz-rs/src/lib.rs
@@ -135,6 +135,6 @@ pub mod __internal {
     // exported for derive macro to avoid code duplication...
     pub use crate::{
         merkleization::{merkleize, mix_in_selector},
-        ser::serialize_composite_from_components,
+        ser::{serialize_composite_from_components, Part},
     };
 }

--- a/ssz-rs/src/lib.rs
+++ b/ssz-rs/src/lib.rs
@@ -135,6 +135,6 @@ pub mod __internal {
     // exported for derive macro to avoid code duplication...
     pub use crate::{
         merkleization::{merkleize, mix_in_selector},
-        ser::{serialize_composite_from_components, Part},
+        ser::Serializer,
     };
 }

--- a/ssz-rs/src/list.rs
+++ b/ssz-rs/src/list.rs
@@ -5,7 +5,7 @@ use crate::{
     merkleization::{
         elements_to_chunks, merkleize, mix_in_length, pack, MerkleizationError, Merkleized, Node,
     },
-    ser::{serialize_composite, Serialize, SerializeError},
+    ser::{Serialize, SerializeError, Serializer},
     SimpleSerialize, Sized,
 };
 #[cfg(feature = "serde")]
@@ -177,7 +177,11 @@ where
         if self.len() > N {
             return Err(InstanceError::Bounded { bound: N, provided: self.len() }.into())
         }
-        serialize_composite(&self.data, buffer)
+        let mut serializer = Serializer::default();
+        for element in &self.data {
+            serializer.with_element(element)?;
+        }
+        serializer.serialize(buffer)
     }
 }
 

--- a/ssz-rs/src/vector.rs
+++ b/ssz-rs/src/vector.rs
@@ -3,7 +3,7 @@ use crate::{
     error::{Error, InstanceError, TypeError},
     lib::*,
     merkleization::{elements_to_chunks, merkleize, pack, MerkleizationError, Merkleized, Node},
-    ser::{serialize_composite, Serialize, SerializeError},
+    ser::{Serialize, SerializeError, Serializer},
     SimpleSerialize, Sized,
 };
 #[cfg(feature = "serde")]
@@ -181,7 +181,11 @@ where
         if N == 0 {
             return Err(TypeError::InvalidBound(N).into())
         }
-        serialize_composite(&self.data, buffer)
+        let mut serializer = Serializer::default();
+        for element in &self.data {
+            serializer.with_element(element)?;
+        }
+        serializer.serialize(buffer)
     }
 }
 


### PR DESCRIPTION
minor but also skips a redundant iteration over the variable lengths summation that can be done inline like the fixed lengths summation