### PR TITLE
error on extra input when deserializing `Union[None]` for some SSZ union type

### DIFF
--- a/ssz-rs-derive/src/lib.rs
+++ b/ssz-rs-derive/src/lib.rs
@@ -304,7 +304,15 @@ fn derive_deserialize_impl(data: &Data) -> TokenStream {
                         }
                         Fields::Unit => {
                             quote_spanned! { variant.span() =>
-                                0 => Ok(Self::None),
+                                0 => {
+                                    if encoding.len() != 1 {
+                                        return Err(DeserializeError::AdditionalInput {
+                                            provided: encoding.len(),
+                                            expected: 1,
+                                        })
+                                    }
+                                    Ok(Self::None)
+                                },
                             }
                         }
                         _ => unreachable!(),


### PR DESCRIPTION
discovered in the Oak Security audit

> Excess bytes in the encoding of None do not trigger errors