### PR TITLE
skip some duplicate checks when deserializing fixed types

### DIFF
--- a/ssz-rs/src/de.rs
+++ b/ssz-rs/src/de.rs
@@ -68,14 +68,8 @@ fn deserialize_fixed_homogeneous_composite<T>(encoding: &[u8]) -> Result<Vec<T>,
 where
     T: SimpleSerialize,
 {
-    let remainder = encoding.len() % T::size_hint();
-    if remainder != 0 {
-        return Err(DeserializeError::AdditionalInput {
-            provided: encoding.len(),
-            // SAFETY: checked subtraction is unnecessary, as encoding.len() > remainder; qed
-            expected: encoding.len() - remainder,
-        })
-    }
+    // NOTE: Callers have already validated `encoding` is correctly sized
+    debug_assert_eq!(encoding.len() % T::size_hint(), 0);
 
     let mut elements = vec![];
     for chunk in encoding.chunks_exact(T::size_hint()) {


### PR DESCRIPTION
from Oak Security audit:

> When deserializing Array, List, and Vector objects, depending on whether they are fixed or variable, one of two functions is called within deserialize_homogeneous_composite - deserialize_variable_homogeneous_composite or deserialize_fixed_homogeneous_composite.
The latter is called when the type is fixed, and the corresponding deserialize functions have already validated the length of the object to be a multiple of the default value of that type obtained using T::size_hint. An example for the Array type is the validation performed in ssz-rs/src/array.rs:51-65.
Nevertheless, the deserialize_fixed_homogeneous_composite function in lines 71-78 validates whether the modulo of the length of the deserialized object and the default size for its type is different from zero. Bearing in mind the fact that in the previous step this size was multiplied by N, it means that consequently there is no possibility that the modulo will be different from zero. Ultimately, it is therefore a redundant piece of code.

