### PR TITLE
feat: derive Hash for merkle node

### DIFF
--- a/ssz-rs/src/merkleization/node.rs
+++ b/ssz-rs/src/merkleization/node.rs
@@ -1,7 +1,7 @@
 use crate::{lib::*, merkleization::BYTES_PER_CHUNK, prelude::*, utils::write_bytes_to_lower_hex};
 
 /// A node in a merkle tree.
-#[derive(Default, Clone, Copy, Eq, SimpleSerialize)]
+#[derive(Default, Clone, Copy, Eq, Hash, SimpleSerialize)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Node(
     #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_hex"))] [u8; BYTES_PER_CHUNK],


### PR DESCRIPTION
while `Node` represents a hash itself, it would be useful for `Node` to implement `Hash`. for example, there are multiple instances in the ethereum consensus spec where we would like to key by the [`Root`](https://github.com/ralexstokes/ethereum-consensus/blob/46ca1716f2b1651e59b8a565b5bbcadf6b052fa5/src/primitives.rs#L8) of some data structure.