### PR TITLE
refactor ser/de into `Serializable` trait without merkle caps

### DIFF
--- a/ssz-rs-derive/src/lib.rs
+++ b/ssz-rs-derive/src/lib.rs
@@ -557,7 +557,7 @@ pub fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
             #deserialize_impl
         }
 
-        #impl_impl ssz_rs::Sized for #name_impl {
+        #impl_impl ssz_rs::Serializable for #name_impl {
             fn is_variable_size() -> bool {
                 #is_variable_size_impl
             }

--- a/ssz-rs/src/array.rs
+++ b/ssz-rs/src/array.rs
@@ -9,14 +9,14 @@ use crate::{
     lib::*,
     merkleization::{elements_to_chunks, merkleize, pack, MerkleizationError, Merkleized, Node},
     ser::{Serialize, SerializeError, Serializer},
-    SimpleSerialize, Sized,
+    Serializable, SimpleSerialize,
 };
 
 macro_rules! define_ssz_for_array_of_size {
     ($n: literal) => {
-        impl<T> Sized for [T; $n]
+        impl<T> Serializable for [T; $n]
         where
-            T: SimpleSerialize,
+            T: Serializable,
         {
             fn is_variable_size() -> bool {
                 T::is_variable_size()
@@ -29,7 +29,7 @@ macro_rules! define_ssz_for_array_of_size {
 
         impl<T> Serialize for [T; $n]
         where
-            T: SimpleSerialize,
+            T: Serializable,
         {
             fn serialize(&self, buffer: &mut Vec<u8>) -> Result<usize, SerializeError> {
                 if $n == 0 {
@@ -45,7 +45,7 @@ macro_rules! define_ssz_for_array_of_size {
 
         impl<T> Deserialize for [T; $n]
         where
-            T: SimpleSerialize,
+            T: Serializable,
         {
             fn deserialize(encoding: &[u8]) -> Result<Self, DeserializeError> {
                 if $n == 0 {

--- a/ssz-rs/src/bitlist.rs
+++ b/ssz-rs/src/bitlist.rs
@@ -6,7 +6,7 @@ use crate::{
         merkleize, mix_in_length, pack_bytes, MerkleizationError, Merkleized, Node, BITS_PER_CHUNK,
     },
     ser::{Serialize, SerializeError},
-    SimpleSerialize, Sized,
+    Serializable, SimpleSerialize,
 };
 use bitvec::prelude::{BitVec, Lsb0};
 
@@ -115,7 +115,7 @@ impl<const N: usize> DerefMut for Bitlist<N> {
     }
 }
 
-impl<const N: usize> Sized for Bitlist<N> {
+impl<const N: usize> Serializable for Bitlist<N> {
     fn is_variable_size() -> bool {
         true
     }

--- a/ssz-rs/src/bitvector.rs
+++ b/ssz-rs/src/bitvector.rs
@@ -4,7 +4,7 @@ use crate::{
     lib::*,
     merkleization::{merkleize, pack_bytes, MerkleizationError, Merkleized, Node, BITS_PER_CHUNK},
     ser::{Serialize, SerializeError},
-    SimpleSerialize, Sized,
+    Serializable, SimpleSerialize,
 };
 use bitvec::{
     field::BitField,
@@ -102,7 +102,7 @@ impl<const N: usize> DerefMut for Bitvector<N> {
     }
 }
 
-impl<const N: usize> Sized for Bitvector<N> {
+impl<const N: usize> Serializable for Bitvector<N> {
     fn is_variable_size() -> bool {
         false
     }

--- a/ssz-rs/src/boolean.rs
+++ b/ssz-rs/src/boolean.rs
@@ -3,10 +3,10 @@ use crate::{
     lib::*,
     merkleization::{MerkleizationError, Merkleized, Node},
     ser::{Serialize, SerializeError},
-    SimpleSerialize, Sized,
+    Serializable, SimpleSerialize,
 };
 
-impl Sized for bool {
+impl Serializable for bool {
     fn is_variable_size() -> bool {
         false
     }

--- a/ssz-rs/src/de.rs
+++ b/ssz-rs/src/de.rs
@@ -2,7 +2,7 @@ use crate::{
     error::{InstanceError, TypeError},
     lib::*,
     ser::BYTES_PER_LENGTH_OFFSET,
-    SimpleSerialize,
+    Serializable,
 };
 
 /// Deserialization errors.
@@ -66,7 +66,7 @@ pub trait Deserialize {
 
 fn deserialize_fixed_homogeneous_composite<T>(encoding: &[u8]) -> Result<Vec<T>, DeserializeError>
 where
-    T: SimpleSerialize,
+    T: Serializable,
 {
     // NOTE: Callers have already validated `encoding` is correctly sized
     debug_assert_eq!(encoding.len() % T::size_hint(), 0);
@@ -83,7 +83,7 @@ fn deserialize_variable_homogeneous_composite<T>(
     encoding: &[u8],
 ) -> Result<Vec<T>, DeserializeError>
 where
-    T: SimpleSerialize,
+    T: Deserialize,
 {
     if encoding.is_empty() {
         return Ok(vec![])
@@ -132,7 +132,7 @@ where
 
 pub fn deserialize_homogeneous_composite<T>(encoding: &[u8]) -> Result<Vec<T>, DeserializeError>
 where
-    T: SimpleSerialize,
+    T: Serializable,
 {
     if T::is_variable_size() {
         deserialize_variable_homogeneous_composite(encoding)

--- a/ssz-rs/src/lib.rs
+++ b/ssz-rs/src/lib.rs
@@ -85,9 +85,9 @@ mod lib {
 
 pub(crate) const BITS_PER_BYTE: u32 = 8;
 
-/// `Sized` is a trait for types that can
-/// provide sizing information relevant for the SSZ spec.
-pub trait Sized {
+/// `Serializable` is a trait for types that can be
+/// serialized and deserialized according to the SSZ spec.
+pub trait Serializable: Serialize + Deserialize {
     // is this type variable or fixed size?
     fn is_variable_size() -> bool;
 
@@ -96,9 +96,10 @@ pub trait Sized {
     fn size_hint() -> usize;
 }
 
-/// `SimpleSerialize` is a trait for types
-/// conforming to the SSZ spec.
-pub trait SimpleSerialize: Serialize + Deserialize + Sized + Merkleized {}
+/// `SimpleSerialize` is a trait for types conforming to the SSZ spec.
+/// These types can be encoded and decoded while also supporting the
+/// merkelization scheme of SSZ.
+pub trait SimpleSerialize: Serializable + Merkleized {}
 
 mod exports {
     pub use crate::{
@@ -112,7 +113,7 @@ mod exports {
         uint::U256,
         utils::{deserialize, serialize},
         vector::Vector,
-        SimpleSerialize, Sized,
+        Serializable, SimpleSerialize,
     };
 }
 

--- a/ssz-rs/src/list.rs
+++ b/ssz-rs/src/list.rs
@@ -185,16 +185,16 @@ where
         self.data.clear();
     }
 
-    pub fn iter_mut(&mut self) -> IterMut<'_, T, N> {
+    pub fn iter_mut(&mut self) -> IterMut<'_, T> {
         IterMut { inner: self.data.iter_mut() }
     }
 }
 
-pub struct IterMut<'a, T, const N: usize> {
+pub struct IterMut<'a, T> {
     inner: slice::IterMut<'a, T>,
 }
 
-impl<'a, T, const N: usize> Iterator for IterMut<'a, T, N> {
+impl<'a, T> Iterator for IterMut<'a, T> {
     type Item = &'a mut T;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/ssz-rs/src/ser.rs
+++ b/ssz-rs/src/ser.rs
@@ -1,7 +1,7 @@
 use crate::{
     error::{InstanceError, TypeError},
     lib::*,
-    SimpleSerialize,
+    Serializable,
 };
 
 // NOTE: if this is changed, go change in `ssz_derive` as well!
@@ -99,7 +99,7 @@ impl Serializer {
         Ok(total_size)
     }
 
-    pub fn with_element<T: SimpleSerialize>(&mut self, element: &T) -> Result<(), SerializeError> {
+    pub fn with_element<T: Serializable>(&mut self, element: &T) -> Result<(), SerializeError> {
         let mut element_buffer = Vec::with_capacity(T::size_hint());
         element.serialize(&mut element_buffer)?;
 

--- a/ssz-rs/src/uint.rs
+++ b/ssz-rs/src/uint.rs
@@ -3,7 +3,7 @@ use crate::{
     lib::*,
     merkleization::{pack_bytes, MerkleizationError, Merkleized, Node},
     ser::{Serialize, SerializeError},
-    SimpleSerialize, Sized, BITS_PER_BYTE,
+    Serializable, SimpleSerialize, BITS_PER_BYTE,
 };
 use num_bigint::BigUint;
 
@@ -14,7 +14,7 @@ fn bits_to_bytes(count: u32) -> usize {
 
 macro_rules! define_uint {
     ($uint:ty) => {
-        impl Sized for $uint {
+        impl Serializable for $uint {
             fn is_variable_size() -> bool {
                 false
             }
@@ -116,7 +116,7 @@ impl From<u64> for U256 {
     }
 }
 
-impl Sized for U256 {
+impl Serializable for U256 {
     fn is_variable_size() -> bool {
         false
     }

--- a/ssz-rs/src/union.rs
+++ b/ssz-rs/src/union.rs
@@ -3,7 +3,7 @@ use crate::{
     lib::*,
     merkleization::{mix_in_selector, MerkleizationError, Merkleized, Node},
     ser::{Serialize, SerializeError},
-    SimpleSerialize, Sized,
+    Serializable, SimpleSerialize,
 };
 
 /// `SimpleSerialize` is implemented for `Option` as a convenience
@@ -13,7 +13,7 @@ use crate::{
 ///     Some(T),
 /// }
 /// The SSZ schema for this value would be `Union[None, T]`.
-impl<T: SimpleSerialize> Sized for Option<T> {
+impl<T: Serializable> Serializable for Option<T> {
     fn is_variable_size() -> bool {
         true
     }
@@ -25,7 +25,7 @@ impl<T: SimpleSerialize> Sized for Option<T> {
 
 impl<T> Serialize for Option<T>
 where
-    T: SimpleSerialize,
+    T: Serializable,
 {
     fn serialize(&self, buffer: &mut Vec<u8>) -> Result<usize, SerializeError> {
         match self {
@@ -41,7 +41,7 @@ where
 
 impl<T> Deserialize for Option<T>
 where
-    T: SimpleSerialize,
+    T: Serializable,
 {
     fn deserialize(encoding: &[u8]) -> Result<Self, DeserializeError> {
         if encoding.is_empty() {

--- a/ssz-rs/src/utils.rs
+++ b/ssz-rs/src/utils.rs
@@ -1,11 +1,11 @@
-use crate::{de::DeserializeError, lib::*, ser::SerializeError, SimpleSerialize};
+use crate::{de::DeserializeError, lib::*, ser::SerializeError, Serializable};
 
 /// `serialize` is a convenience function for taking a value that
 /// implements `SimpleSerialize` and attempting to encode it to
 /// a `Vec<u8>` according to the SSZ spec.
 pub fn serialize<T>(value: &T) -> Result<Vec<u8>, SerializeError>
 where
-    T: SimpleSerialize,
+    T: Serializable,
 {
     let mut result = vec![];
     value.serialize(&mut result)?;
@@ -17,7 +17,7 @@ where
 /// and attempting to deserialize that value from the byte representation.
 pub fn deserialize<T>(encoding: &[u8]) -> Result<T, DeserializeError>
 where
-    T: SimpleSerialize,
+    T: Serializable,
 {
     T::deserialize(encoding)
 }


### PR DESCRIPTION
following up on #92 -- there is desire to separate the merkleization capability from the ser/de capability for SSZ types

previously, all of these capabilities where coupled under the `SimpleSerialize` trait.

now, the ser/de stuff has been split into a `Serializable` trait and `SimpleSerialize` simply requires that along w/ the merkle trait `Merkleized`
 
while doing this refactor, it became clear that the `Sized` trait could be bundled and it doesn't really make much sense on it's own

beyond that, there are various refactors to limit the scope of traits required to their bare minimum.

this should support future proc macro work that allows a user to choose just the serde and forgo the merkle functionality