### PR TITLE
Avoid allocating default container when deserializing

### DIFF
--- a/ssz-rs/src/lib.rs
+++ b/ssz-rs/src/lib.rs
@@ -135,6 +135,7 @@ pub mod prelude {
 pub mod __internal {
     // exported for derive macro to avoid code duplication...
     pub use crate::{
+        de::ContainerDeserializer,
         merkleization::{merkleize, mix_in_selector},
         ser::Serializer,
     };


### PR DESCRIPTION
Right now, the `SimpleSerialize` proc macro will allocate a `Default::default()` instance when deserializing and then set each field accordingly.

We can save some space by parsing the input to get all relevant spans (along w/ validating invariants of the data) and then making an instance of the type once after we know where to segment the incoming encoding for each field.

This PR implements this change.