### PR TITLE
use more permissive index type for {Vector, List}::index_mut

### DIFF
--- a/ssz-rs/src/list.rs
+++ b/ssz-rs/src/list.rs
@@ -102,11 +102,11 @@ where
 // NOTE: implement `IndexMut` rather than `DerefMut` to ensure
 // the inner data is not mutated without being able to
 // track which elements changed
-impl<T, const N: usize> IndexMut<usize> for List<T, N>
+impl<T, Idx: SliceIndex<[T]>, const N: usize> IndexMut<Idx> for List<T, N>
 where
     T: Serializable,
 {
-    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+    fn index_mut(&mut self, index: Idx) -> &mut Self::Output {
         &mut self.data[index]
     }
 }

--- a/ssz-rs/src/vector.rs
+++ b/ssz-rs/src/vector.rs
@@ -106,11 +106,11 @@ where
 // NOTE: implement `IndexMut` rather than `DerefMut` to ensure
 // the inner data is not mutated without being able to
 // track which elements changed
-impl<T, const N: usize> IndexMut<usize> for Vector<T, N>
+impl<T, Idx: SliceIndex<[T]>, const N: usize> IndexMut<Idx> for Vector<T, N>
 where
     T: Serializable,
 {
-    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+    fn index_mut(&mut self, index: Idx) -> &mut Self::Output {
         &mut self.data[index]
     }
 }


### PR DESCRIPTION
the `index_mut` implementation should also support index types other than `usize` to support batch editing operations ("copy N bytes into these N bytes of the source")

the existing implementation restricted the index type to just `usize` so that this information could be used to inform caching strategies

this PR relaxes the constraint for now, with the caveat that we will likely need to constrain the implementation a bit so we can actually get the indexing data during a call to `index_mut` (e.g. only allow `index_mut` for `usize` and the `Range` family of index types) so we can concretely get the actual indexes mutated