### PR TITLE
Simplify `serde` impl

### DIFF
--- a/ssz-rs/Cargo.toml
+++ b/ssz-rs/Cargo.toml
@@ -13,8 +13,8 @@ exclude = ["tests/data"]
 
 [features]
 default = ["serde", "std"]
-serde = ["dep:serde", "hex"]
 std = ["bitvec/default", "sha2/default", "num-bigint/default"]
+serde = ["dep:serde", "hex"]
 
 [dependencies]
 bitvec = { version = "1.0.0", default-features = false, features = ["alloc"] }

--- a/ssz-rs/Cargo.toml
+++ b/ssz-rs/Cargo.toml
@@ -7,27 +7,26 @@ license = "MIT OR Apache-2.0"
 readme = "../README.md"
 description = "ethereum's simple serialize"
 repository = "https://github.com/ralexstokes/ssz-rs"
-exclude = [
-    "tests/data",
-]
+exclude = ["tests/data"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
 default = ["serde", "std"]
-std = [
-    "bitvec/default",
-    "sha2/default",
-    "num-bigint/default",
-]
 serde = ["dep:serde", "hex"]
+std = ["bitvec/default", "sha2/default", "num-bigint/default"]
 
 [dependencies]
 bitvec = { version = "1.0.0", default-features = false, features = ["alloc"] }
 ssz_rs_derive = { path = "../ssz-rs-derive", version = "0.9.0" }
-sha2 = { version ="0.9.8", default-features = false}
-serde = { version = "1.0", default-features = false, features = ["alloc", "derive"], optional = true }
-hex = { version = "0.4.3", default-features = false, features = ["alloc"], optional = true }
+sha2 = { version = "0.9.8", default-features = false }
+serde = { version = "1.0", default-features = false, features = [
+    "alloc",
+    "derive",
+], optional = true }
+hex = { version = "0.4.3", default-features = false, features = [
+    "alloc",
+], optional = true }
 num-bigint = { version = "0.4.3", default-features = false }
 
 [dev-dependencies]

--- a/ssz-rs/src/lib.rs
+++ b/ssz-rs/src/lib.rs
@@ -69,6 +69,7 @@ mod lib {
             fmt::{Debug, Display, Formatter},
             ops::{Deref, DerefMut, Index, IndexMut},
             slice::{IterMut, SliceIndex},
+            str::FromStr,
         },
         iter::Enumerate,
     };


### PR DESCRIPTION
Fixes #110 

This change should fix the bug surfaced in #110. It also simplifies the `serde` implementation across the crate by using the `serde` `derive` macros where possible