### PR TITLE
clean up implementation of `Node`

### DIFF
--- a/ssz-rs/Cargo.toml
+++ b/ssz-rs/Cargo.toml
@@ -30,7 +30,6 @@ hex = { version = "0.4.3", default-features = false, features = [
 num-bigint = { version = "0.4.3", default-features = false }
 
 [dev-dependencies]
-hex-literal = "0.3.3"
 snap = "1.0"
 project-root = "0.2.2"
 serde_json = "1.0.81"

--- a/ssz-rs/examples/another_container.rs
+++ b/ssz-rs/examples/another_container.rs
@@ -91,8 +91,9 @@ fn main() {
     assert_eq!(recovered_value, value);
 
     let root = value.hash_tree_root().expect("can find root");
-    let expected_root = "69b0ce69dfbc8abb8ae4fba564dcb813f5cc5b93c76d2b3d0689687c35821036";
-    assert_eq!(hex::encode(root), expected_root);
+    let expected_root =
+        hex::decode("69b0ce69dfbc8abb8ae4fba564dcb813f5cc5b93c76d2b3d0689687c35821036").unwrap();
+    assert_eq!(root.as_ref(), expected_root);
 
     let value = SerializableStruct {
         a: 61,

--- a/ssz-rs/src/lib.rs
+++ b/ssz-rs/src/lib.rs
@@ -49,7 +49,7 @@ mod ser;
 mod serde;
 mod uint;
 mod union;
-mod utils;
+pub mod utils;
 mod vector;
 
 mod lib {
@@ -71,7 +71,7 @@ mod lib {
             slice::{IterMut, SliceIndex},
             str::FromStr,
         },
-        iter::Enumerate,
+        iter::{Enumerate, ExactSizeIterator},
     };
 
     #[cfg(not(feature = "std"))]

--- a/ssz-rs/src/lib.rs
+++ b/ssz-rs/src/lib.rs
@@ -46,7 +46,7 @@ mod list;
 mod merkleization;
 mod ser;
 #[cfg(feature = "serde")]
-mod serde;
+pub mod serde;
 mod uint;
 mod union;
 pub mod utils;

--- a/ssz-rs/src/list.rs
+++ b/ssz-rs/src/list.rs
@@ -76,6 +76,22 @@ where
     }
 }
 
+impl<T, const N: usize> TryFrom<&[T]> for List<T, N>
+where
+    T: Serializable + Clone,
+{
+    type Error = Error;
+
+    fn try_from(data: &[T]) -> Result<Self, Self::Error> {
+        if data.len() > N {
+            let len = data.len();
+            Err(Error::Instance(InstanceError::Bounded { bound: N, provided: len }))
+        } else {
+            Ok(Self { data: data.to_vec() })
+        }
+    }
+}
+
 impl<T, const N: usize> Deref for List<T, N>
 where
     T: Serializable,

--- a/ssz-rs/src/merkleization/mod.rs
+++ b/ssz-rs/src/merkleization/mod.rs
@@ -270,7 +270,12 @@ mod tests {
     use super::*;
     use crate as ssz_rs;
     use crate::prelude::*;
-    use hex_literal::hex;
+
+    macro_rules! hex {
+        ($input:expr) => {
+            hex::decode($input).unwrap()
+        };
+    }
 
     #[test]
     fn test_packing_basic_types_simple() {
@@ -363,42 +368,69 @@ mod tests {
     fn test_naive_merkleize_chunks() {
         let chunks = vec![0u8; 2 * BYTES_PER_CHUNK];
         let root = merkleize_chunks(&chunks, 2).expect("can merkleize");
-        assert_eq!(root, hex!("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b"));
+        assert_eq!(
+            root.as_ref(),
+            hex!("f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b")
+        );
 
         let chunks = vec![1u8; 2 * BYTES_PER_CHUNK];
         let root = merkleize_chunks(&chunks, 2).expect("can merkleize");
-        assert_eq!(root, hex!("7c8975e1e60a5c8337f28edf8c33c3b180360b7279644a9bc1af3c51e6220bf5"));
+        assert_eq!(
+            root.as_ref(),
+            hex!("7c8975e1e60a5c8337f28edf8c33c3b180360b7279644a9bc1af3c51e6220bf5")
+        );
 
         let chunks = vec![0u8; BYTES_PER_CHUNK];
         let root = merkleize_chunks(&chunks, 4).expect("can merkleize");
-        assert_eq!(root, hex!("db56114e00fdd4c1f85c892bf35ac9a89289aaecb1ebd0a96cde606a748b5d71"));
+        assert_eq!(
+            root.as_ref(),
+            hex!("db56114e00fdd4c1f85c892bf35ac9a89289aaecb1ebd0a96cde606a748b5d71")
+        );
 
         let chunks = vec![1u8; BYTES_PER_CHUNK];
         let root = merkleize_chunks(&chunks, 4).expect("can merkleize");
-        assert_eq!(root, hex!("29797eded0e83376b70f2bf034cc0811ae7f1414653b1d720dfd18f74cf13309"));
+        assert_eq!(
+            root.as_ref(),
+            hex!("29797eded0e83376b70f2bf034cc0811ae7f1414653b1d720dfd18f74cf13309")
+        );
 
         let chunks = vec![2u8; BYTES_PER_CHUNK];
         let root = merkleize_chunks(&chunks, 8).expect("can merkleize");
-        assert_eq!(root, hex!("fa4cf775712aa8a2fe5dcb5a517d19b2e9effcf58ff311b9fd8e4a7d308e6d00"));
+        assert_eq!(
+            root.as_ref(),
+            hex!("fa4cf775712aa8a2fe5dcb5a517d19b2e9effcf58ff311b9fd8e4a7d308e6d00")
+        );
 
         let chunks = vec![1u8; 5 * BYTES_PER_CHUNK];
         let root = merkleize_chunks(&chunks, 8).expect("can merkleize");
-        assert_eq!(root, hex!("0ae67e34cba4ad2bbfea5dc39e6679b444021522d861fab00f05063c54341289"));
+        assert_eq!(
+            root.as_ref(),
+            hex!("0ae67e34cba4ad2bbfea5dc39e6679b444021522d861fab00f05063c54341289")
+        );
     }
 
     #[test]
     fn test_merkleize_chunks() {
         let chunks = vec![1u8; 3 * BYTES_PER_CHUNK];
         let root = merkleize_chunks_with_virtual_padding(&chunks, 4).expect("can merkleize");
-        assert_eq!(root, hex!("65aa94f2b59e517abd400cab655f42821374e433e41b8fe599f6bb15484adcec"));
+        assert_eq!(
+            root.as_ref(),
+            hex!("65aa94f2b59e517abd400cab655f42821374e433e41b8fe599f6bb15484adcec")
+        );
 
         let chunks = vec![1u8; 5 * BYTES_PER_CHUNK];
         let root = merkleize_chunks_with_virtual_padding(&chunks, 8).expect("can merkleize");
-        assert_eq!(root, hex!("0ae67e34cba4ad2bbfea5dc39e6679b444021522d861fab00f05063c54341289"));
+        assert_eq!(
+            root.as_ref(),
+            hex!("0ae67e34cba4ad2bbfea5dc39e6679b444021522d861fab00f05063c54341289")
+        );
 
         let chunks = vec![1u8; 6 * BYTES_PER_CHUNK];
         let root = merkleize_chunks_with_virtual_padding(&chunks, 8).expect("can merkleize");
-        assert_eq!(root, hex!("0ef7df63c204ef203d76145627b8083c49aa7c55ebdee2967556f55a4f65a238"));
+        assert_eq!(
+            root.as_ref(),
+            hex!("0ef7df63c204ef203d76145627b8083c49aa7c55ebdee2967556f55a4f65a238")
+        );
     }
 
     #[test]
@@ -406,12 +438,18 @@ mod tests {
         let chunks = vec![1u8; 5 * BYTES_PER_CHUNK];
         let root =
             merkleize_chunks_with_virtual_padding(&chunks, 2usize.pow(10)).expect("can merkleize");
-        assert_eq!(root, hex!("2647cb9e26bd83eeb0982814b2ac4d6cc4a65d0d98637f1a73a4c06d3db0e6ce"));
+        assert_eq!(
+            root.as_ref(),
+            hex!("2647cb9e26bd83eeb0982814b2ac4d6cc4a65d0d98637f1a73a4c06d3db0e6ce")
+        );
 
         let chunks = vec![1u8; 70 * BYTES_PER_CHUNK];
         let root =
             merkleize_chunks_with_virtual_padding(&chunks, 2usize.pow(63)).expect("can merkleize");
-        assert_eq!(root, hex!("9317695d95b5a3b46e976b5a9cbfcfccb600accaddeda9ac867cc9669b862979"));
+        assert_eq!(
+            root.as_ref(),
+            hex!("9317695d95b5a3b46e976b5a9cbfcfccb600accaddeda9ac867cc9669b862979")
+        );
     }
 
     #[test]
@@ -447,14 +485,20 @@ mod tests {
         ])
         .unwrap();
         let root = a_list.hash_tree_root().expect("can compute root");
-        assert_eq!(root, hex!("d20d2246e1438d88de46f6f41c7b041f92b673845e51f2de93b944bf599e63b1"));
+        assert_eq!(
+            root.as_ref(),
+            hex!("d20d2246e1438d88de46f6f41c7b041f92b673845e51f2de93b944bf599e63b1")
+        );
     }
 
     #[test]
     fn test_hash_tree_root_of_empty_list() {
         let mut a_list = List::<u16, 1024>::try_from(vec![]).unwrap();
         let root = a_list.hash_tree_root().expect("can compute root");
-        assert_eq!(root, hex!("c9eece3e14d3c3db45c38bbf69a4cb7464981e2506d8424a0ba450dad9b9af30"));
+        assert_eq!(
+            root.as_ref(),
+            hex!("c9eece3e14d3c3db45c38bbf69a4cb7464981e2506d8424a0ba450dad9b9af30")
+        );
     }
 
     #[test]
@@ -501,7 +545,10 @@ mod tests {
         };
 
         let root = foo.hash_tree_root().expect("can make root");
-        assert_eq!(root, hex!("7078155bf8f0dc42d8afccec8d9b5aeb54f0a2e8e58fcef3e723f6a867232ce7"));
+        assert_eq!(
+            root.as_ref(),
+            hex!("7078155bf8f0dc42d8afccec8d9b5aeb54f0a2e8e58fcef3e723f6a867232ce7")
+        );
 
         let mut original_foo = foo.clone();
 
@@ -510,24 +557,36 @@ mod tests {
         foo.e = Bar::A(33);
 
         let root = original_foo.hash_tree_root().expect("can make root");
-        assert_eq!(root, hex!("7078155bf8f0dc42d8afccec8d9b5aeb54f0a2e8e58fcef3e723f6a867232ce7"));
+        assert_eq!(
+            root.as_ref(),
+            hex!("7078155bf8f0dc42d8afccec8d9b5aeb54f0a2e8e58fcef3e723f6a867232ce7")
+        );
 
         let root = foo.hash_tree_root().expect("can make root");
-        assert_eq!(root, hex!("0063bfcfabbca567483a2ee859fcfafb958329489eb328ac7f07790c7df1b231"));
+        assert_eq!(
+            root.as_ref(),
+            hex!("0063bfcfabbca567483a2ee859fcfafb958329489eb328ac7f07790c7df1b231")
+        );
 
         let encoding = serialize(&original_foo).expect("can serialize");
 
         let mut restored_foo = Foo::deserialize(&encoding).expect("can deserialize");
 
         let root = restored_foo.hash_tree_root().expect("can make root");
-        assert_eq!(root, hex!("7078155bf8f0dc42d8afccec8d9b5aeb54f0a2e8e58fcef3e723f6a867232ce7"));
+        assert_eq!(
+            root.as_ref(),
+            hex!("7078155bf8f0dc42d8afccec8d9b5aeb54f0a2e8e58fcef3e723f6a867232ce7")
+        );
 
         restored_foo.b[2] = 44u32;
         restored_foo.d.pop();
         restored_foo.e = Bar::A(33);
 
         let root = foo.hash_tree_root().expect("can make root");
-        assert_eq!(root, hex!("0063bfcfabbca567483a2ee859fcfafb958329489eb328ac7f07790c7df1b231"));
+        assert_eq!(
+            root.as_ref(),
+            hex!("0063bfcfabbca567483a2ee859fcfafb958329489eb328ac7f07790c7df1b231")
+        );
     }
 
     #[test]
@@ -557,6 +616,6 @@ mod tests {
         let expected_root =
             hex::decode("4400000000000000000000000000000000000000000000000000000000000000")
                 .unwrap();
-        assert_eq!(foo_root, expected_root);
+        assert_eq!(foo_root.as_ref(), expected_root);
     }
 }

--- a/ssz-rs/src/serde.rs
+++ b/ssz-rs/src/serde.rs
@@ -29,7 +29,7 @@ impl From<FromHexError> for HexError {
 #[cfg(feature = "std")]
 impl std::error::Error for HexError {}
 
-fn try_bytes_from_hex_str(s: &str) -> Result<Vec<u8>, HexError> {
+pub fn try_bytes_from_hex_str(s: &str) -> Result<Vec<u8>, HexError> {
     let target = s.strip_prefix(HEX_ENCODING_PREFIX).ok_or(HexError::MissingPrefix)?;
     let data = hex::decode(target)?;
     Ok(data)

--- a/ssz-rs/src/utils.rs
+++ b/ssz-rs/src/utils.rs
@@ -22,15 +22,62 @@ where
     T::deserialize(encoding)
 }
 
-pub(crate) fn write_bytes_to_lower_hex<T: AsRef<[u8]>>(
-    f: &mut fmt::Formatter<'_>,
-    data: T,
-) -> fmt::Result {
-    if f.alternate() {
-        write!(f, "0x")?;
-    }
+#[inline]
+fn write_hex_from_bytes<D: AsRef<[u8]>>(f: &mut fmt::Formatter<'_>, data: D) -> fmt::Result {
     for i in data.as_ref() {
         write!(f, "{i:02x}")?;
     }
     Ok(())
+}
+
+pub fn write_bytes_to_lower_hex<T: AsRef<[u8]>>(
+    f: &mut fmt::Formatter<'_>,
+    data: T,
+) -> fmt::Result {
+    write!(f, "0x")?;
+    write_hex_from_bytes(f, data)
+}
+
+pub fn write_bytes_to_lower_hex_display<T: AsRef<[u8]> + ExactSizeIterator>(
+    f: &mut fmt::Formatter<'_>,
+    data: T,
+) -> fmt::Result {
+    let len = data.len();
+    let (first, last) = if len >= 4 { ((0..2), Some(len - 2..len)) } else { ((0..len), None) };
+    let data = data.as_ref();
+    write!(f, "0x")?;
+    write_hex_from_bytes(f, &data[first])?;
+    if let Some(last) = last {
+        write!(f, "…")?;
+        write_hex_from_bytes(f, &data[last])?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct Fmt(Vec<u8>);
+
+    impl fmt::Debug for Fmt {
+        fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+            write_bytes_to_lower_hex(f, self.0.iter())
+        }
+    }
+
+    impl fmt::Display for Fmt {
+        fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+            write_bytes_to_lower_hex_display(f, self.0.iter())
+        }
+    }
+
+    #[test]
+    fn test_fmt() {
+        let data = Fmt((0u8..3).collect::<Vec<_>>());
+        let s = format!("{data:?}");
+        assert_eq!(s, "0x000102");
+        let s = format!("{data}");
+        assert_eq!(s, "0x000102");
+    }
 }

--- a/ssz-rs/src/vector.rs
+++ b/ssz-rs/src/vector.rs
@@ -45,6 +45,25 @@ impl<T: Serializable, const N: usize> TryFrom<Vec<T>> for Vector<T, N> {
     }
 }
 
+impl<T, const N: usize> TryFrom<&[T]> for Vector<T, N>
+where
+    T: Serializable + Clone,
+{
+    type Error = Error;
+
+    fn try_from(data: &[T]) -> Result<Self, Self::Error> {
+        if N == 0 {
+            return Err(Error::Type(TypeError::InvalidBound(N)))
+        }
+        if data.len() != N {
+            let len = data.len();
+            Err(Error::Instance(InstanceError::Exact { required: N, provided: len }))
+        } else {
+            Ok(Self { data: data.to_vec() })
+        }
+    }
+}
+
 impl<T, const N: usize> fmt::Debug for Vector<T, N>
 where
     T: Serializable + fmt::Debug,


### PR DESCRIPTION
simplify trait impls to expose a "bytes-like" thing 
normalize `fmt` impls for hex-printing