### PR TITLE
extend `transparent` proc macro attr behavior to Serialize and Deserialize

### DIFF
--- a/ssz-rs-derive/tests/mod.rs
+++ b/ssz-rs-derive/tests/mod.rs
@@ -1,13 +1,13 @@
 use ssz_rs::prelude::*;
 use ssz_rs_derive::SimpleSerialize;
 
-#[derive(Debug, SimpleSerialize)]
+#[derive(Debug, SimpleSerialize, PartialEq, Eq)]
 struct Foo {
     a: u8,
     b: u32,
 }
 
-#[derive(Debug, SimpleSerialize)]
+#[derive(Debug, SimpleSerialize, PartialEq, Eq)]
 #[ssz(transparent)]
 enum Bar {
     A(u8),
@@ -22,6 +22,12 @@ fn test_transparent_helper() {
     let mut f = Foo { a: 23, b: 445 };
     let f_root = f.hash_tree_root().unwrap();
     let mut bar = Bar::B(f);
+
+    let mut buf = vec![];
+    let _ = bar.serialize(&mut buf).unwrap();
+    let recovered_bar = Bar::deserialize(&buf).unwrap();
+    assert_eq!(bar, recovered_bar);
+
     let bar_root = bar.hash_tree_root().unwrap();
     assert_eq!(f_root, bar_root);
 }

--- a/ssz-rs/src/de.rs
+++ b/ssz-rs/src/de.rs
@@ -24,6 +24,9 @@ pub enum DeserializeError {
     OffsetNotIncreasing { start: usize, end: usize },
     /// An offset was absent when expected.
     MissingOffset,
+    /// No corresponding variant of the requested enum was present. (refer to `transparent`
+    /// attribute of `ssz-rs-derive` macro)
+    NoMatchingVariant,
 }
 
 impl From<InstanceError> for DeserializeError {
@@ -52,6 +55,7 @@ impl Display for DeserializeError {
             DeserializeError::InvalidOffsetsLength(len) => write!(f, "the offsets length provided {len} is not a multiple of the size per length offset {BYTES_PER_LENGTH_OFFSET} bytes"),
             DeserializeError::OffsetNotIncreasing { start, end } => write!(f, "invalid offset points to byte {end} before byte {start}"),
             DeserializeError::MissingOffset => write!(f, "an offset was missing when deserializing a variable-sized type"),
+            DeserializeError::NoMatchingVariant => write!(f, "no corresponding variant of the requested enum was present"),
         }
     }
 }


### PR DESCRIPTION
this simple does a "brute force" approach to deserializing a `transparent` derived type

otherwise, we would need to extend the `Deserialize` trait with some kind of `DeserializeSeed` function (following serde's approach)