### PR TITLE
Bump alloy dependency

### DIFF
--- a/ssz-rs/Cargo.toml
+++ b/ssz-rs/Cargo.toml
@@ -27,7 +27,7 @@ serde = { version = "1.0", default-features = false, features = [
 hex = { version = "0.4.3", default-features = false, features = [
     "alloc",
 ], optional = true }
-alloy-primitives = { version = "0.4.2", default-features = false }
+alloy-primitives = { version = "^0.5.0", default-features = false }
 
 [dev-dependencies]
 snap = "1.0"


### PR DESCRIPTION
Bump version up to 0.5. Needed because the reth stack uses `^0.5` so updates to `mev-rs` leveraging `reth` crates are not possible due to versioning conflicts in `ethereum-consensus`. After this is merged the `ssz-rs` dependency in `ethereum-consesus` can be pumped to latest which should resolve the conflicts?