### PR TITLE
Remove methods that reimplement underlying functionality of `List` and `Vector`

### DIFF
--- a/ssz-rs/src/lib.rs
+++ b/ssz-rs/src/lib.rs
@@ -111,7 +111,7 @@ mod lib {
         pub use std::*;
     }
 
-    pub use self::core::{any, cmp, fmt, slice};
+    pub use self::core::{any, cmp, fmt};
 
     pub use self::{
         cmp::Ordering,

--- a/ssz-rs/src/list.rs
+++ b/ssz-rs/src/list.rs
@@ -105,6 +105,15 @@ where
     }
 }
 
+impl<T, const N: usize> DerefMut for List<T, N>
+where
+    T: Serializable,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.data
+    }
+}
+
 impl<T, Idx: SliceIndex<[T]>, const N: usize> Index<Idx> for List<T, N>
 where
     T: Serializable,
@@ -116,9 +125,6 @@ where
     }
 }
 
-// NOTE: implement `IndexMut` rather than `DerefMut` to ensure
-// the inner data is not mutated without being able to
-// track which elements changed
 impl<T, Idx: SliceIndex<[T]>, const N: usize> IndexMut<Idx> for List<T, N>
 where
     T: Serializable,
@@ -190,22 +196,6 @@ impl<T, const N: usize> List<T, N>
 where
     T: SimpleSerialize,
 {
-    pub fn push(&mut self, element: T) {
-        self.data.push(element);
-    }
-
-    pub fn pop(&mut self) -> Option<T> {
-        self.data.pop()
-    }
-
-    pub fn clear(&mut self) {
-        self.data.clear();
-    }
-
-    pub fn iter_mut(&mut self) -> IterMut<'_, T> {
-        IterMut { inner: self.data.iter_mut() }
-    }
-
     fn assemble_chunks(&mut self) -> Result<Vec<u8>, MerkleizationError> {
         if T::is_composite_type() {
             let count = self.len();
@@ -213,18 +203,6 @@ where
         } else {
             pack(self)
         }
-    }
-}
-
-pub struct IterMut<'a, T> {
-    inner: slice::IterMut<'a, T>,
-}
-
-impl<'a, T> Iterator for IterMut<'a, T> {
-    type Item = &'a mut T;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.inner.next()
     }
 }
 

--- a/ssz-rs/src/vector.rs
+++ b/ssz-rs/src/vector.rs
@@ -116,6 +116,15 @@ where
     }
 }
 
+impl<T, const N: usize> DerefMut for Vector<T, N>
+where
+    T: Serializable,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.data
+    }
+}
+
 impl<T, Idx: SliceIndex<[T]>, const N: usize> Index<Idx> for Vector<T, N>
 where
     T: Serializable,
@@ -127,9 +136,6 @@ where
     }
 }
 
-// NOTE: implement `IndexMut` rather than `DerefMut` to ensure
-// the inner data is not mutated without being able to
-// track which elements changed
 impl<T, Idx: SliceIndex<[T]>, const N: usize> IndexMut<Idx> for Vector<T, N>
 where
     T: Serializable,
@@ -198,28 +204,6 @@ where
             Error::Type(err) => DeserializeError::InvalidType(err),
             _ => unreachable!("no other error variant can be returned at this point"),
         })
-    }
-}
-
-impl<T, const N: usize> Vector<T, N>
-where
-    T: Serializable,
-{
-    pub fn iter_mut(&mut self) -> IterMut<'_, T> {
-        let inner = self.data.iter_mut();
-        IterMut { inner }
-    }
-}
-
-pub struct IterMut<'a, T: 'a> {
-    inner: slice::IterMut<'a, T>,
-}
-
-impl<'a, T> Iterator for IterMut<'a, T> {
-    type Item = &'a mut T;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.inner.next()
     }
 }
 


### PR DESCRIPTION
Originally, the mutable APIs into the underlying type that `List` and `Vector` wrap were specialized to the local wrapping types so that mutations could be tracked along the way to support caching a la #17.

I'd like to release a v1 of this library and won't have caching support so go ahead and drop the specialized implementations here, in lieu of just exposing the full functionality of the wrapped types.