### PR TITLE
refactor: drop `mut` on `HashTreeRoot::hash_tree_root`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,13 +31,15 @@ jobs:
           cache-on-failure: true
 
       - name: Build
-        run: cargo build --all-targets --all-features --verbose
+        run: cargo build --all-targets --all-features --workspace --verbose
 
       - name: Build `no-std`
-        run: cargo build --no-default-features --all-targets --verbose
+        run: cargo build --no-default-features --all-targets --workspace --verbose
 
       - name: Run tests
-        run: cargo test --all-features --all-targets --verbose
+        run: |
+         cargo test --all-features --all-targets --workspace --verbose
+         cargo test --doc
 
   lint:
     runs-on: ubuntu-latest
@@ -59,7 +61,7 @@ jobs:
         run: cargo +nightly fmt --all --check
 
       - name: Check clippy
-        run: cargo +nightly clippy --all-targets --all-features --verbose -- -D warnings
+        run: cargo +nightly clippy --all-targets --all-features --workspace --verbose -- -D warnings
 
   coverage:
     runs-on: ubuntu-latest

--- a/justfile
+++ b/justfile
@@ -1,11 +1,12 @@
 test:
-    cargo test --all-features --all-targets
+    cargo test --all-features --workspace --all-targets
+    cargo test --doc
 fmt:
     cargo +nightly fmt --all
 lint: fmt
-    cargo +nightly clippy --all-targets --all-features
+    cargo +nightly clippy --all-features --workspace --all-targets
 build:
-    cargo build --all-targets --all-features
+    cargo build --all-features --workspace --all-targets
 build-no-std:
-    cargo build --no-default-features --all-targets
+    cargo build --no-default-features --workspace --all-targets
 run-ci: lint build build-no-std test

--- a/ssz-rs-derive/src/lib.rs
+++ b/ssz-rs-derive/src/lib.rs
@@ -404,13 +404,13 @@ fn derive_merkleization_impl(
     let (impl_generics, ty_generics, _) = generics.split_for_impl();
     quote! {
         impl #impl_generics #name #ty_generics {
-            fn assemble_chunks(&mut self) -> Result<Vec<u8>, ssz_rs::MerkleizationError> {
+            fn assemble_chunks(&self) -> Result<Vec<u8>, ssz_rs::MerkleizationError> {
                 #chunks_impl
             }
         }
 
         impl #impl_generics ssz_rs::HashTreeRoot for #name #ty_generics {
-            fn hash_tree_root(&mut self) -> Result<ssz_rs::Node, ssz_rs::MerkleizationError> {
+            fn hash_tree_root(&self) -> Result<ssz_rs::Node, ssz_rs::MerkleizationError> {
                 #hash_tree_root_impl
             }
         }
@@ -600,7 +600,7 @@ fn derive_prove_impl(data: &Data, name: &Ident, generics: &Generics) -> TokenStr
                     let field_name = field.ident.as_ref().expect("only named fields");
                     quote! {
                          #i => {
-                            let child = &mut self.#field_name;
+                            let child = &self.#field_name;
                             prover.compute_proof(child)
                         }
                     }
@@ -665,8 +665,8 @@ fn derive_prove_impl(data: &Data, name: &Ident, generics: &Generics) -> TokenStr
                         (
                             quote! {
                                 Self::None => {
-                                    let mut leaf = 0usize;
-                                    prover.compute_proof(&mut leaf)
+                                    let leaf = 0usize;
+                                    prover.compute_proof(&leaf)
                                 }
                             },
                             quote! {
@@ -706,12 +706,12 @@ fn derive_prove_impl(data: &Data, name: &Ident, generics: &Generics) -> TokenStr
 
     quote! {
         impl #impl_generics ssz_rs::Prove for #name #ty_generics {
-            fn chunks(&mut self) -> Result<Vec<u8>, ssz_rs::MerkleizationError> {
+            fn chunks(&self) -> Result<Vec<u8>, ssz_rs::MerkleizationError> {
                 #chunks_impl
             }
 
             fn prove_element(
-                &mut self,
+                &self,
                 index: usize,
                 prover: &mut ssz_rs::proofs::Prover,
             ) -> Result<(), ssz_rs::MerkleizationError> {

--- a/ssz-rs-derive/tests/mod.rs
+++ b/ssz-rs-derive/tests/mod.rs
@@ -18,7 +18,7 @@ enum Bar {
 }
 
 fn generalized_index_for_bar(
-    object: &mut Bar,
+    object: &Bar,
     path: Path,
 ) -> Result<GeneralizedIndex, MerkleizationError> {
     match object {
@@ -27,7 +27,7 @@ fn generalized_index_for_bar(
     }
 }
 
-fn prove_for_bar(object: &mut Bar, path: Path) -> Result<ProofAndWitness, MerkleizationError> {
+fn prove_for_bar(object: &Bar, path: Path) -> Result<ProofAndWitness, MerkleizationError> {
     match object {
         Bar::A(value) => value.prove(path),
         Bar::B(value) => value.prove(path),
@@ -40,7 +40,7 @@ struct Wrapper(Foo);
 #[derive(Debug, PartialEq, Eq, SimpleSerialize)]
 struct WrappedList(List<u8, 23>);
 
-fn can_serde<T: Serializable + Eq + fmt::Debug>(data: &mut T) {
+fn can_serde<T: Serializable + Eq + fmt::Debug>(data: &T) {
     let mut buf = vec![];
     let _ = data.serialize(&mut buf).unwrap();
     let recovered = T::deserialize(&buf).unwrap();
@@ -50,13 +50,13 @@ fn can_serde<T: Serializable + Eq + fmt::Debug>(data: &mut T) {
 #[test]
 fn test_transparent_helper() {
     // derive traits for "regular" types
-    let mut container = Foo {
+    let container = Foo {
         a: 23,
         b: 445,
         c: List::<usize, 45>::try_from(vec![9, 8, 7, 6, 5, 4]).unwrap(),
         d: U256::from(234234),
     };
-    can_serde(&mut container);
+    can_serde(&container);
 
     let container_root = container.hash_tree_root().unwrap();
 
@@ -85,43 +85,43 @@ fn test_transparent_helper() {
     }
 
     // derive traits in "transparent" mode
-    let mut inner = 22;
-    let mut bar = Bar::A(inner);
-    can_serde(&mut bar);
+    let inner = 22;
+    let bar = Bar::A(inner);
+    can_serde(&bar);
 
     let inner_root = inner.hash_tree_root().unwrap();
     let bar_root = bar.hash_tree_root().unwrap();
     assert_eq!(inner_root, bar_root);
 
     // `bar` just wraps a primitive type, so `path` is empty.
-    let index = generalized_index_for_bar(&mut bar, &[]).unwrap();
+    let index = generalized_index_for_bar(&bar, &[]).unwrap();
     assert_eq!(index, 1);
-    let result = generalized_index_for_bar(&mut bar, &["a".into()]);
+    let result = generalized_index_for_bar(&bar, &["a".into()]);
     assert!(result.is_err());
 
     let path = &[];
-    let (proof, witness) = prove_for_bar(&mut bar, path).unwrap();
+    let (proof, witness) = prove_for_bar(&bar, path).unwrap();
     assert_eq!(witness, inner_root);
     assert_eq!(witness, bar_root);
     assert!(proof.verify(witness).is_ok());
 
     // repeat transparent with other variant
-    let mut inner = container.clone();
+    let inner = container.clone();
     let inner_root = inner.hash_tree_root().unwrap();
-    let mut bar = Bar::B(inner);
-    can_serde(&mut bar);
+    let bar = Bar::B(inner);
+    can_serde(&bar);
 
     let bar_root = bar.hash_tree_root().unwrap();
     assert_eq!(inner_root, bar_root);
 
     for (i, (path, _)) in container_paths.iter().enumerate() {
-        let index = generalized_index_for_bar(&mut bar, path).unwrap();
+        let index = generalized_index_for_bar(&bar, path).unwrap();
         assert_eq!(index, container_indices[i]);
     }
 
     for (i, pair) in container_paths.iter().enumerate() {
         let path = &pair.0;
-        let (proof, witness) = prove_for_bar(&mut bar, path).unwrap();
+        let (proof, witness) = prove_for_bar(&bar, path).unwrap();
         assert_eq!(witness, container_root);
         assert!(proof.verify(witness).is_ok());
         assert_eq!((proof, witness), container_proofs[i]);
@@ -131,8 +131,8 @@ fn test_transparent_helper() {
     // for a wrapped type without "decoration"
     let mut buf = vec![];
     let container_serialization = container.serialize(&mut buf).unwrap();
-    let mut wrapped = Wrapper(container);
-    can_serde(&mut wrapped);
+    let wrapped = Wrapper(container);
+    can_serde(&wrapped);
     buf.clear();
     let wrapped_serialization = wrapped.serialize(&mut buf).unwrap();
     assert_eq!(container_serialization, wrapped_serialization);
@@ -164,7 +164,7 @@ fn test_transparent_helper() {
 
     // for a wrapped type with "decoration"
     let mut buf = vec![];
-    let mut inner = List::<u8, 23>::try_from(vec![10, 11, 12]).unwrap();
+    let inner = List::<u8, 23>::try_from(vec![10, 11, 12]).unwrap();
     let inner_serialization = inner.serialize(&mut buf).unwrap();
     let inner_root = inner.hash_tree_root().unwrap();
     let inner_paths =
@@ -183,8 +183,8 @@ fn test_transparent_helper() {
         inner_proofs.push((proof, witness));
     }
 
-    let mut wrapped = WrappedList(inner);
-    can_serde(&mut wrapped);
+    let wrapped = WrappedList(inner);
+    can_serde(&wrapped);
     buf.clear();
     let wrapped_serialization = wrapped.serialize(&mut buf).unwrap();
     assert_eq!(inner_serialization, wrapped_serialization);

--- a/ssz-rs-test-gen/src/main.rs
+++ b/ssz-rs-test-gen/src/main.rs
@@ -442,7 +442,7 @@ impl Generator {
                         r#"
                 #[test]
                 fn test_{ssz_type}_{name}() {{
-                    let mut value = {value};
+                    let value = {value};
                     let encoding = serialize(&value);
                     let expected_encoding = read_ssz_snappy_from_test_data("{target_data_path}");
                     assert_eq!(encoding, expected_encoding);
@@ -450,7 +450,7 @@ impl Generator {
                     let recovered_value: {rust_type} = deserialize(&expected_encoding);
                     assert_eq!(recovered_value, value);
 
-                    let root = hash_tree_root(&mut value);
+                    let root = hash_tree_root(&value);
                     let expected_root = root_from_hex("{root}");
                     assert_eq!(root, expected_root);
                 }}

--- a/ssz-rs/examples/another_container.rs
+++ b/ssz-rs/examples/another_container.rs
@@ -49,7 +49,7 @@ struct SerializableStruct {
 }
 
 fn main() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 51972,
         b: List::<u16, 128>::try_from(vec![48645]).unwrap(),
         c: 46,

--- a/ssz-rs/examples/container_with_some_types.rs
+++ b/ssz-rs/examples/container_with_some_types.rs
@@ -69,7 +69,7 @@ fn main() {
         }
     };
 
-    let mut restored_example = match Foo::<4>::deserialize(&encoding) {
+    let restored_example = match Foo::<4>::deserialize(&encoding) {
         Ok(value) => value,
         Err(err) => {
             eprintln!("some error decoding: {err}");

--- a/ssz-rs/examples/proofs.rs
+++ b/ssz-rs/examples/proofs.rs
@@ -25,7 +25,7 @@ struct ComplexTestStruct {
     g: Vector<VarTestStruct, 2>,
 }
 
-fn compute_and_verify_proof<T: SimpleSerialize>(data: &mut T, path: Path) {
+fn compute_and_verify_proof<T: SimpleSerialize>(data: &T, path: Path) {
     let (proof, witness) = data.prove(path).unwrap();
     assert_eq!(witness, data.hash_tree_root().unwrap());
     dbg!(&proof);
@@ -36,11 +36,11 @@ fn compute_and_verify_proof<T: SimpleSerialize>(data: &mut T, path: Path) {
 }
 
 fn main() {
-    let mut data = 8u8;
+    let data = 8u8;
     let path = &[];
-    compute_and_verify_proof(&mut data, path);
+    compute_and_verify_proof(&data, path);
 
-    let mut data = ComplexTestStruct {
+    let data = ComplexTestStruct {
         a: 51972,
         b: List::<u16, 128>::try_from(vec![48645]).unwrap(),
         c: 46,
@@ -69,20 +69,20 @@ fn main() {
     };
 
     let path = &["a".into()];
-    compute_and_verify_proof(&mut data, path);
+    compute_and_verify_proof(&data, path);
 
     let path = &["b".into(), 0.into()];
-    compute_and_verify_proof(&mut data, path);
+    compute_and_verify_proof(&data, path);
 
     let path = &["e".into(), "a".into()];
-    compute_and_verify_proof(&mut data, path);
+    compute_and_verify_proof(&data, path);
 
     let path = &["e".into(), "b".into(), 0.into()];
-    compute_and_verify_proof(&mut data, path);
+    compute_and_verify_proof(&data, path);
 
     let path = &["e".into(), "b".into(), 33.into()];
-    compute_and_verify_proof(&mut data, path);
+    compute_and_verify_proof(&data, path);
 
     let path = &["g".into(), 1.into(), "b".into(), 0.into()];
-    compute_and_verify_proof(&mut data, path);
+    compute_and_verify_proof(&data, path);
 }

--- a/ssz-rs/src/array.rs
+++ b/ssz-rs/src/array.rs
@@ -76,7 +76,7 @@ impl<T, const N: usize> HashTreeRoot for [T; N]
 where
     T: SimpleSerialize,
 {
-    fn hash_tree_root(&mut self) -> Result<Node, MerkleizationError> {
+    fn hash_tree_root(&self) -> Result<Node, MerkleizationError> {
         let chunks = self.chunks()?;
         merkleize(&chunks, None)
     }
@@ -121,24 +121,20 @@ impl<T, const N: usize> Prove for [T; N]
 where
     T: SimpleSerialize,
 {
-    fn chunks(&mut self) -> Result<Vec<u8>, MerkleizationError> {
+    fn chunks(&self) -> Result<Vec<u8>, MerkleizationError> {
         if T::is_composite_type() {
             let count = self.len();
-            elements_to_chunks(self.iter_mut().enumerate(), count)
+            elements_to_chunks(self.iter().enumerate(), count)
         } else {
             pack(self)
         }
     }
 
-    fn prove_element(
-        &mut self,
-        index: usize,
-        prover: &mut Prover,
-    ) -> Result<(), MerkleizationError> {
+    fn prove_element(&self, index: usize, prover: &mut Prover) -> Result<(), MerkleizationError> {
         if index >= N {
             Err(MerkleizationError::InvalidInnerIndex)
         } else {
-            let child = &mut self[index];
+            let child = &self[index];
             prover.compute_proof(child)
         }
     }

--- a/ssz-rs/src/bitlist.rs
+++ b/ssz-rs/src/bitlist.rs
@@ -54,7 +54,7 @@ impl<const N: usize> Default for Bitlist<N> {
 
 impl<const N: usize> Bitlist<N> {
     /// Return the bit at `index`. `None` if index is out-of-bounds.
-    pub fn get(&mut self, index: usize) -> Option<bool> {
+    pub fn get(&self, index: usize) -> Option<bool> {
         self.0.get(index).map(|value| *value)
     }
 
@@ -179,7 +179,7 @@ impl<const N: usize> Deserialize for Bitlist<N> {
 }
 
 impl<const N: usize> HashTreeRoot for Bitlist<N> {
-    fn hash_tree_root(&mut self) -> Result<Node, MerkleizationError> {
+    fn hash_tree_root(&self) -> Result<Node, MerkleizationError> {
         let chunks = self.pack_bits()?;
         let data_root = merkleize(&chunks, Some(Self::chunk_count()))?;
         Ok(mix_in_length(data_root, self.len()))
@@ -218,7 +218,7 @@ impl<const N: usize> GeneralizedIndexable for Bitlist<N> {
 }
 
 impl<const N: usize> Prove for Bitlist<N> {
-    fn chunks(&mut self) -> Result<Vec<u8>, MerkleizationError> {
+    fn chunks(&self) -> Result<Vec<u8>, MerkleizationError> {
         self.pack_bits()
     }
 

--- a/ssz-rs/src/bitvector.rs
+++ b/ssz-rs/src/bitvector.rs
@@ -67,7 +67,7 @@ impl<const N: usize> Default for Bitvector<N> {
 
 impl<const N: usize> Bitvector<N> {
     /// Return the bit at `index`. `None` if index is out-of-bounds.
-    pub fn get(&mut self, index: usize) -> Option<bool> {
+    pub fn get(&self, index: usize) -> Option<bool> {
         self.0.get(index).map(|value| *value)
     }
 
@@ -168,7 +168,7 @@ impl<const N: usize> Deserialize for Bitvector<N> {
 }
 
 impl<const N: usize> HashTreeRoot for Bitvector<N> {
-    fn hash_tree_root(&mut self) -> Result<Node, MerkleizationError> {
+    fn hash_tree_root(&self) -> Result<Node, MerkleizationError> {
         let chunks = self.pack_bits()?;
         merkleize(&chunks, Some(Self::chunk_count()))
     }
@@ -205,7 +205,7 @@ impl<const N: usize> GeneralizedIndexable for Bitvector<N> {
 }
 
 impl<const N: usize> Prove for Bitvector<N> {
-    fn chunks(&mut self) -> Result<Vec<u8>, MerkleizationError> {
+    fn chunks(&self) -> Result<Vec<u8>, MerkleizationError> {
         self.pack_bits()
     }
 }

--- a/ssz-rs/src/boolean.rs
+++ b/ssz-rs/src/boolean.rs
@@ -43,7 +43,7 @@ impl Deserialize for bool {
 }
 
 impl HashTreeRoot for bool {
-    fn hash_tree_root(&mut self) -> Result<Node, MerkleizationError> {
+    fn hash_tree_root(&self) -> Result<Node, MerkleizationError> {
         let mut node = Node::default();
         if *self {
             node[0] = 1;
@@ -63,7 +63,7 @@ impl GeneralizedIndexable for bool {
 }
 
 impl Prove for bool {
-    fn chunks(&mut self) -> Result<Vec<u8>, MerkleizationError> {
+    fn chunks(&self) -> Result<Vec<u8>, MerkleizationError> {
         let mut vec = vec![0u8; BYTES_PER_CHUNK];
         if *self {
             vec[0] = 1;

--- a/ssz-rs/src/container.rs
+++ b/ssz-rs/src/container.rs
@@ -242,15 +242,15 @@ mod tests {
             b: u64,
         }
 
-        let mut data = BasicContainer { a: 2343, d: true };
+        let data = BasicContainer { a: 2343, d: true };
         let path = &["a".into()];
-        compute_and_verify_proof_for_path(&mut data, path);
+        compute_and_verify_proof_for_path(&data, path);
 
-        let mut data = BasicContainer { a: 2343, d: true };
+        let data = BasicContainer { a: 2343, d: true };
         let path = &["d".into()];
-        compute_and_verify_proof_for_path(&mut data, path);
+        compute_and_verify_proof_for_path(&data, path);
 
-        let mut data = AnotherContainer {
+        let data = AnotherContainer {
             a: 23089,
             b: false,
             c: List::<bool, 32>::try_from(vec![true, false, false, false, true]).unwrap(),
@@ -265,21 +265,21 @@ mod tests {
             &["e".into()],
         ];
         for &path in paths {
-            compute_and_verify_proof_for_path(&mut data, path);
+            compute_and_verify_proof_for_path(&data, path);
         }
 
         let inner = V::try_from(vec![11u8; 25]).unwrap();
-        let mut data = Foo { a: W::try_from(vec![inner; 888]).unwrap(), b: 23 };
+        let data = Foo { a: W::try_from(vec![inner; 888]).unwrap(), b: 23 };
         let paths: &[Path] = &[&["a".into()], &["a".into(), 333.into(), 20.into()], &["b".into()]];
         for &path in paths {
-            compute_and_verify_proof_for_path(&mut data, path);
+            compute_and_verify_proof_for_path(&data, path);
         }
 
         let inner = X::try_from(vec![U256::from(11usize); 70]).unwrap();
-        let mut data = Bar { a: Y::try_from(vec![inner; 2]).unwrap(), b: 88888 };
+        let data = Bar { a: Y::try_from(vec![inner; 2]).unwrap(), b: 88888 };
         let paths: &[Path] = &[&["a".into()], &["a".into(), 0.into(), 64.into()], &["b".into()]];
         for &path in paths {
-            compute_and_verify_proof_for_path(&mut data, path);
+            compute_and_verify_proof_for_path(&data, path);
         }
     }
 }

--- a/ssz-rs/src/lib.rs
+++ b/ssz-rs/src/lib.rs
@@ -182,7 +182,7 @@ mod exports {
     where
         T: crate::Serializable,
     {
-        let mut result = vec![];
+        let mut result = crate::lib::Vec::new();
         value.serialize(&mut result)?;
         Ok(result)
     }

--- a/ssz-rs/src/lib.rs
+++ b/ssz-rs/src/lib.rs
@@ -76,7 +76,7 @@
 //! }
 //!
 //! let path = &["value".into(), 23.into()];
-//! let mut data = YetAnotherType::default();
+//! let data = YetAnotherType::default();
 //! let (proof, witness) = data.prove(path).unwrap();
 //! assert!(proof.verify(witness).is_ok());
 //! ```

--- a/ssz-rs/src/merkleization/merkleize.rs
+++ b/ssz-rs/src/merkleization/merkleize.rs
@@ -17,7 +17,7 @@ const DECORATION_GENERALIZED_INDEX: GeneralizedIndex = 3;
 /// Types that can provide the root of their corresponding Merkle tree following the SSZ spec.
 pub trait HashTreeRoot {
     /// Compute the "hash tree root" of `Self`.
-    fn hash_tree_root(&mut self) -> Result<Node, Error>;
+    fn hash_tree_root(&self) -> Result<Node, Error>;
 
     /// Indicate the "composite" nature of `Self`.
     fn is_composite_type() -> bool {
@@ -204,7 +204,7 @@ pub fn merkleize(chunks: &[u8], limit: Option<usize>) -> Result<Node, Error> {
     merkleize_chunks_with_virtual_padding(chunks, leaf_count)
 }
 
-fn mix_in_decoration(root: Node, mut decoration: usize) -> Node {
+fn mix_in_decoration(root: Node, decoration: usize) -> Node {
     let decoration_data = decoration.hash_tree_root().expect("can merkleize usize");
 
     let mut hasher = Sha256::new();
@@ -222,7 +222,7 @@ pub fn mix_in_selector(root: Node, selector: usize) -> Node {
 }
 
 pub(crate) fn elements_to_chunks<'a, T: HashTreeRoot + 'a>(
-    elements: impl Iterator<Item = (usize, &'a mut T)>,
+    elements: impl Iterator<Item = (usize, &'a T)>,
     count: usize,
 ) -> Result<Vec<u8>, Error> {
     let mut chunks = vec![0u8; count * BYTES_PER_CHUNK];
@@ -239,7 +239,7 @@ pub struct Tree(Vec<u8>);
 impl Tree {
     pub fn mix_in_decoration(
         &mut self,
-        mut decoration: usize,
+        decoration: usize,
         hasher: &mut Sha256,
     ) -> Result<(), Error> {
         let target_node = &mut self[DECORATION_GENERALIZED_INDEX];
@@ -496,7 +496,7 @@ mod tests {
 
     #[test]
     fn test_hash_tree_root_of_list() {
-        let mut a_list = List::<u16, 1024>::try_from(vec![
+        let a_list = List::<u16, 1024>::try_from(vec![
             65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
             65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
             65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
@@ -537,7 +537,7 @@ mod tests {
 
     #[test]
     fn test_hash_tree_root_of_empty_list() {
-        let mut a_list = List::<u16, 1024>::try_from(vec![]).unwrap();
+        let a_list = List::<u16, 1024>::try_from(vec![]).unwrap();
         let root = a_list.hash_tree_root().expect("can compute root");
         assert_eq!(
             root,
@@ -598,7 +598,7 @@ mod tests {
             )
         );
 
-        let mut original_foo = foo.clone();
+        let original_foo = foo.clone();
 
         foo.b[2] = 44u32;
         foo.d.pop();
@@ -647,7 +647,7 @@ mod tests {
 
     #[test]
     fn test_simple_serialize_of_root() {
-        let mut root = Node::default();
+        let root = Node::default();
         let mut result = vec![];
         let _ = root.serialize(&mut result).expect("can encode");
         let expected_encoding = vec![0; 32];
@@ -667,7 +667,7 @@ mod tests {
             a: U256,
         }
 
-        let mut foo = Foo { a: U256::from(68) };
+        let foo = Foo { a: U256::from(68) };
         let foo_root = foo.hash_tree_root().unwrap();
         let expected_root = decode_node_from_hex(
             "4400000000000000000000000000000000000000000000000000000000000000",

--- a/ssz-rs/src/merkleization/merkleize.rs
+++ b/ssz-rs/src/merkleization/merkleize.rs
@@ -5,6 +5,7 @@ use crate::{
     ser::Serialize,
     GeneralizedIndex,
 };
+#[cfg(feature = "serde")]
 use alloy_primitives::hex::FromHex;
 use sha2::{Digest, Sha256};
 
@@ -251,6 +252,7 @@ impl Tree {
         Ok(())
     }
 
+    #[cfg(feature = "serde")]
     fn nodes(&self) -> impl Iterator<Item = Node> + '_ {
         self.0.chunks(BYTES_PER_CHUNK).map(|chunk| Node::from_hex(chunk).unwrap())
     }

--- a/ssz-rs/src/merkleization/node.rs
+++ b/ssz-rs/src/merkleization/node.rs
@@ -41,7 +41,7 @@ impl Serializable for Node {
 }
 
 impl HashTreeRoot for Node {
-    fn hash_tree_root(&mut self) -> Result<Node, MerkleizationError> {
+    fn hash_tree_root(&self) -> Result<Node, MerkleizationError> {
         let chunks = self.chunks()?;
         Ok(Node::try_from(chunks.as_slice()).expect("is right size"))
     }
@@ -54,7 +54,7 @@ impl HashTreeRoot for Node {
 impl GeneralizedIndexable for Node {}
 
 impl Prove for Node {
-    fn chunks(&mut self) -> Result<Vec<u8>, MerkleizationError> {
+    fn chunks(&self) -> Result<Vec<u8>, MerkleizationError> {
         Ok(self.to_vec())
     }
 }

--- a/ssz-rs/src/uint.rs
+++ b/ssz-rs/src/uint.rs
@@ -56,7 +56,7 @@ macro_rules! define_uint {
         }
 
         impl HashTreeRoot for $uint {
-            fn hash_tree_root(&mut self) -> Result<Node, MerkleizationError> {
+            fn hash_tree_root(&self) -> Result<Node, MerkleizationError> {
                 let root = self.chunks()?;
                 Ok(root.as_slice().try_into().expect("is valid root"))
             }
@@ -73,7 +73,7 @@ macro_rules! define_uint {
         }
 
         impl Prove for $uint {
-            fn chunks(&mut self) -> Result<Vec<u8>, MerkleizationError> {
+            fn chunks(&self) -> Result<Vec<u8>, MerkleizationError> {
                 let mut root = Vec::with_capacity(BYTES_PER_CHUNK);
                 let _ = self.serialize(&mut root)?;
                 pack_bytes(&mut root);
@@ -137,7 +137,7 @@ impl Deserialize for U256 {
 }
 
 impl HashTreeRoot for U256 {
-    fn hash_tree_root(&mut self) -> Result<Node, MerkleizationError> {
+    fn hash_tree_root(&self) -> Result<Node, MerkleizationError> {
         let chunks = self.chunks()?;
         Ok(Node::try_from(chunks.as_slice()).expect("is right size"))
     }
@@ -154,7 +154,7 @@ impl GeneralizedIndexable for U256 {
 }
 
 impl Prove for U256 {
-    fn chunks(&mut self) -> Result<Vec<u8>, MerkleizationError> {
+    fn chunks(&self) -> Result<Vec<u8>, MerkleizationError> {
         Ok(self.as_le_bytes().to_vec())
     }
 }

--- a/ssz-rs/src/union.rs
+++ b/ssz-rs/src/union.rs
@@ -78,7 +78,7 @@ impl<T> HashTreeRoot for Option<T>
 where
     T: SimpleSerialize,
 {
-    fn hash_tree_root(&mut self) -> Result<Node, MerkleizationError> {
+    fn hash_tree_root(&self) -> Result<Node, MerkleizationError> {
         let chunks = Node::try_from(self.chunks()?.as_slice()).expect("is correct size");
         match self {
             Some(_) => Ok(mix_in_selector(chunks, 1)),
@@ -133,7 +133,7 @@ impl<T> Prove for Option<T>
 where
     T: SimpleSerialize,
 {
-    fn chunks(&mut self) -> Result<Vec<u8>, MerkleizationError> {
+    fn chunks(&self) -> Result<Vec<u8>, MerkleizationError> {
         match self {
             Some(value) => {
                 let root = value.hash_tree_root()?;
@@ -143,19 +143,15 @@ where
         }
     }
 
-    fn prove_element(
-        &mut self,
-        index: usize,
-        prover: &mut Prover,
-    ) -> Result<(), MerkleizationError> {
+    fn prove_element(&self, index: usize, prover: &mut Prover) -> Result<(), MerkleizationError> {
         if index >= 2 {
             Err(MerkleizationError::InvalidInnerIndex)
         } else {
             match self {
                 Some(value) => prover.compute_proof(value),
                 None => {
-                    let mut leaf = 0usize;
-                    prover.compute_proof(&mut leaf)
+                    let leaf = 0usize;
+                    prover.compute_proof(&leaf)
                 }
             }
         }
@@ -445,70 +441,70 @@ mod tests {
 
     #[test]
     fn prove_option() {
-        let mut data = Some(11u8);
+        let data = Some(11u8);
         let path = &[0.into()];
-        crate::merkleization::proofs::tests::compute_and_verify_proof_for_path(&mut data, path);
+        crate::merkleization::proofs::tests::compute_and_verify_proof_for_path(&data, path);
 
-        let mut data = Some(11u8);
+        let data = Some(11u8);
         let path = &[1.into()];
-        crate::merkleization::proofs::tests::compute_and_verify_proof_for_path(&mut data, path);
+        crate::merkleization::proofs::tests::compute_and_verify_proof_for_path(&data, path);
 
-        let mut data = Some(U256::from(23423u16));
+        let data = Some(U256::from(23423u16));
         let path = &[0.into()];
-        crate::merkleization::proofs::tests::compute_and_verify_proof_for_path(&mut data, path);
+        crate::merkleization::proofs::tests::compute_and_verify_proof_for_path(&data, path);
 
-        let mut data = Some(U256::from(23423u16));
+        let data = Some(U256::from(23423u16));
         let path = &[1.into()];
-        crate::merkleization::proofs::tests::compute_and_verify_proof_for_path(&mut data, path);
+        crate::merkleization::proofs::tests::compute_and_verify_proof_for_path(&data, path);
 
         let path = &[PathElement::Selector];
-        crate::merkleization::proofs::tests::compute_and_verify_proof_for_path(&mut data, path);
+        crate::merkleization::proofs::tests::compute_and_verify_proof_for_path(&data, path);
 
-        let mut data = Option::<U256>::None;
+        let data = Option::<U256>::None;
         let path = &[0.into()];
-        crate::merkleization::proofs::tests::compute_and_verify_proof_for_path(&mut data, path);
+        crate::merkleization::proofs::tests::compute_and_verify_proof_for_path(&data, path);
 
-        let mut data = Option::<U256>::None;
+        let data = Option::<U256>::None;
         let path = &[1.into()];
-        crate::merkleization::proofs::tests::compute_and_verify_proof_for_path(&mut data, path);
+        crate::merkleization::proofs::tests::compute_and_verify_proof_for_path(&data, path);
 
-        let mut data = Option::<u16>::None;
+        let data = Option::<u16>::None;
         let path = &[0.into()];
-        crate::merkleization::proofs::tests::compute_and_verify_proof_for_path(&mut data, path);
+        crate::merkleization::proofs::tests::compute_and_verify_proof_for_path(&data, path);
 
-        let mut data = Option::<u16>::None;
+        let data = Option::<u16>::None;
         let path = &[1.into()];
-        crate::merkleization::proofs::tests::compute_and_verify_proof_for_path(&mut data, path);
+        crate::merkleization::proofs::tests::compute_and_verify_proof_for_path(&data, path);
 
         let path = &[PathElement::Selector];
-        crate::merkleization::proofs::tests::compute_and_verify_proof_for_path(&mut data, path);
+        crate::merkleization::proofs::tests::compute_and_verify_proof_for_path(&data, path);
     }
 
     #[test]
     fn prove_unions() {
-        let mut data = Boo::default();
+        let data = Boo::default();
         let path = &[0.into()];
-        crate::merkleization::proofs::tests::compute_and_verify_proof_for_path(&mut data, path);
+        crate::merkleization::proofs::tests::compute_and_verify_proof_for_path(&data, path);
 
-        let mut data = Boo::B(Default::default());
+        let data = Boo::B(Default::default());
         let path = &[1.into()];
-        crate::merkleization::proofs::tests::compute_and_verify_proof_for_path(&mut data, path);
+        crate::merkleization::proofs::tests::compute_and_verify_proof_for_path(&data, path);
         let path = &[1.into(), "data".into(), 7.into()];
-        crate::merkleization::proofs::tests::compute_and_verify_proof_for_path(&mut data, path);
+        crate::merkleization::proofs::tests::compute_and_verify_proof_for_path(&data, path);
 
-        let mut data = Boo::C(Default::default());
+        let data = Boo::C(Default::default());
         let path = &[2.into()];
-        crate::merkleization::proofs::tests::compute_and_verify_proof_for_path(&mut data, path);
+        crate::merkleization::proofs::tests::compute_and_verify_proof_for_path(&data, path);
         let path = &[2.into(), 0.into()];
-        crate::merkleization::proofs::tests::compute_and_verify_proof_for_path(&mut data, path);
+        crate::merkleization::proofs::tests::compute_and_verify_proof_for_path(&data, path);
 
-        let mut data = Boo::D(Default::default());
+        let data = Boo::D(Default::default());
         let path = &[3.into()];
-        crate::merkleization::proofs::tests::compute_and_verify_proof_for_path(&mut data, path);
+        crate::merkleization::proofs::tests::compute_and_verify_proof_for_path(&data, path);
 
         let path = &[3.into(), 0.into()];
-        crate::merkleization::proofs::tests::compute_and_verify_proof_for_path(&mut data, path);
+        crate::merkleization::proofs::tests::compute_and_verify_proof_for_path(&data, path);
         let path = &[3.into(), 1.into()];
-        crate::merkleization::proofs::tests::compute_and_verify_proof_for_path(&mut data, path);
+        crate::merkleization::proofs::tests::compute_and_verify_proof_for_path(&data, path);
     }
 }

--- a/ssz-rs/tests/basic_vector.rs
+++ b/ssz-rs/tests/basic_vector.rs
@@ -18,7 +18,7 @@ fn test_basic_vector_vec_bool_0() {
 
 #[test]
 fn test_basic_vector_vec_bool_16_max() {
-    let mut value = Vector::<bool, 16>::try_from(Vec::<bool>::from_iter([
+    let value = Vector::<bool, 16>::try_from(Vec::<bool>::from_iter([
         true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
         true,
     ]))
@@ -32,7 +32,7 @@ fn test_basic_vector_vec_bool_16_max() {
     let recovered_value: Vector<bool, 16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0101010101010101010101010101010100000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -86,7 +86,7 @@ fn test_basic_vector_vec_bool_16_nil() {
 
 #[test]
 fn test_basic_vector_vec_bool_16_zero() {
-    let mut value = Vector::<bool, 16>::try_from(Vec::<bool>::from_iter([
+    let value = Vector::<bool, 16>::try_from(Vec::<bool>::from_iter([
         false, false, false, false, false, false, false, false, false, false, false, false, false,
         false, false, false,
     ]))
@@ -100,7 +100,7 @@ fn test_basic_vector_vec_bool_16_zero() {
     let recovered_value: Vector<bool, 16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -144,7 +144,7 @@ fn test_basic_vector_vec_bool_16_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_bool_1_max() {
-    let mut value = Vector::<bool, 1>::try_from(Vec::<bool>::from_iter([true])).unwrap();
+    let value = Vector::<bool, 1>::try_from(Vec::<bool>::from_iter([true])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/basic_vector/valid/vec_bool_1_max/serialized.ssz_snappy",
@@ -154,7 +154,7 @@ fn test_basic_vector_vec_bool_1_max() {
     let recovered_value: Vector<bool, 1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0100000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -212,7 +212,7 @@ fn test_basic_vector_vec_bool_1_nil() {
 
 #[test]
 fn test_basic_vector_vec_bool_1_zero() {
-    let mut value = Vector::<bool, 1>::try_from(Vec::<bool>::from_iter([false])).unwrap();
+    let value = Vector::<bool, 1>::try_from(Vec::<bool>::from_iter([false])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/basic_vector/valid/vec_bool_1_zero/serialized.ssz_snappy",
@@ -222,7 +222,7 @@ fn test_basic_vector_vec_bool_1_zero() {
     let recovered_value: Vector<bool, 1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -266,7 +266,7 @@ fn test_basic_vector_vec_bool_1_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_bool_2_max() {
-    let mut value = Vector::<bool, 2>::try_from(Vec::<bool>::from_iter([true, true])).unwrap();
+    let value = Vector::<bool, 2>::try_from(Vec::<bool>::from_iter([true, true])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/basic_vector/valid/vec_bool_2_max/serialized.ssz_snappy",
@@ -276,7 +276,7 @@ fn test_basic_vector_vec_bool_2_max() {
     let recovered_value: Vector<bool, 2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0101000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -334,7 +334,7 @@ fn test_basic_vector_vec_bool_2_nil() {
 
 #[test]
 fn test_basic_vector_vec_bool_2_zero() {
-    let mut value = Vector::<bool, 2>::try_from(Vec::<bool>::from_iter([false, false])).unwrap();
+    let value = Vector::<bool, 2>::try_from(Vec::<bool>::from_iter([false, false])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/basic_vector/valid/vec_bool_2_zero/serialized.ssz_snappy",
@@ -344,7 +344,7 @@ fn test_basic_vector_vec_bool_2_zero() {
     let recovered_value: Vector<bool, 2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -388,7 +388,7 @@ fn test_basic_vector_vec_bool_2_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_bool_31_max() {
-    let mut value = Vector::<bool, 31>::try_from(Vec::<bool>::from_iter([
+    let value = Vector::<bool, 31>::try_from(Vec::<bool>::from_iter([
         true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
         true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
         true,
@@ -403,7 +403,7 @@ fn test_basic_vector_vec_bool_31_max() {
     let recovered_value: Vector<bool, 31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0101010101010101010101010101010101010101010101010101010101010100");
     assert_eq!(root, expected_root);
@@ -457,7 +457,7 @@ fn test_basic_vector_vec_bool_31_nil() {
 
 #[test]
 fn test_basic_vector_vec_bool_31_zero() {
-    let mut value = Vector::<bool, 31>::try_from(Vec::<bool>::from_iter([
+    let value = Vector::<bool, 31>::try_from(Vec::<bool>::from_iter([
         false, false, false, false, false, false, false, false, false, false, false, false, false,
         false, false, false, false, false, false, false, false, false, false, false, false, false,
         false, false, false, false, false,
@@ -472,7 +472,7 @@ fn test_basic_vector_vec_bool_31_zero() {
     let recovered_value: Vector<bool, 31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -516,8 +516,7 @@ fn test_basic_vector_vec_bool_31_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_bool_3_max() {
-    let mut value =
-        Vector::<bool, 3>::try_from(Vec::<bool>::from_iter([true, true, true])).unwrap();
+    let value = Vector::<bool, 3>::try_from(Vec::<bool>::from_iter([true, true, true])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/basic_vector/valid/vec_bool_3_max/serialized.ssz_snappy",
@@ -527,7 +526,7 @@ fn test_basic_vector_vec_bool_3_max() {
     let recovered_value: Vector<bool, 3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0101010000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -585,8 +584,7 @@ fn test_basic_vector_vec_bool_3_nil() {
 
 #[test]
 fn test_basic_vector_vec_bool_3_zero() {
-    let mut value =
-        Vector::<bool, 3>::try_from(Vec::<bool>::from_iter([false, false, false])).unwrap();
+    let value = Vector::<bool, 3>::try_from(Vec::<bool>::from_iter([false, false, false])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/basic_vector/valid/vec_bool_3_zero/serialized.ssz_snappy",
@@ -596,7 +594,7 @@ fn test_basic_vector_vec_bool_3_zero() {
     let recovered_value: Vector<bool, 3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -640,7 +638,7 @@ fn test_basic_vector_vec_bool_3_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_bool_4_max() {
-    let mut value =
+    let value =
         Vector::<bool, 4>::try_from(Vec::<bool>::from_iter([true, true, true, true])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -651,7 +649,7 @@ fn test_basic_vector_vec_bool_4_max() {
     let recovered_value: Vector<bool, 4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0101010100000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -709,7 +707,7 @@ fn test_basic_vector_vec_bool_4_nil() {
 
 #[test]
 fn test_basic_vector_vec_bool_4_zero() {
-    let mut value =
+    let value =
         Vector::<bool, 4>::try_from(Vec::<bool>::from_iter([false, false, false, false])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -720,7 +718,7 @@ fn test_basic_vector_vec_bool_4_zero() {
     let recovered_value: Vector<bool, 4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -764,7 +762,7 @@ fn test_basic_vector_vec_bool_4_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_bool_512_max() {
-    let mut value = Vector::<bool, 512>::try_from(Vec::<bool>::from_iter([
+    let value = Vector::<bool, 512>::try_from(Vec::<bool>::from_iter([
         true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
         true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
         true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
@@ -811,7 +809,7 @@ fn test_basic_vector_vec_bool_512_max() {
     let recovered_value: Vector<bool, 512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xbea533dbcce99238f8e459b813178182fbb2903627d119e0e6a91718dee93bec");
     assert_eq!(root, expected_root);
@@ -865,7 +863,7 @@ fn test_basic_vector_vec_bool_512_nil() {
 
 #[test]
 fn test_basic_vector_vec_bool_512_zero() {
-    let mut value = Vector::<bool, 512>::try_from(Vec::<bool>::from_iter([
+    let value = Vector::<bool, 512>::try_from(Vec::<bool>::from_iter([
         false, false, false, false, false, false, false, false, false, false, false, false, false,
         false, false, false, false, false, false, false, false, false, false, false, false, false,
         false, false, false, false, false, false, false, false, false, false, false, false, false,
@@ -917,7 +915,7 @@ fn test_basic_vector_vec_bool_512_zero() {
     let recovered_value: Vector<bool, 512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x536d98837f2dd165a55d5eeae91485954472d56f246df256bf3cae19352a123c");
     assert_eq!(root, expected_root);
@@ -961,7 +959,7 @@ fn test_basic_vector_vec_bool_512_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_bool_513_max() {
-    let mut value = Vector::<bool, 513>::try_from(Vec::<bool>::from_iter([
+    let value = Vector::<bool, 513>::try_from(Vec::<bool>::from_iter([
         true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
         true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
         true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
@@ -1008,7 +1006,7 @@ fn test_basic_vector_vec_bool_513_max() {
     let recovered_value: Vector<bool, 513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5299a985b414f61b75a2c8c15f886b14a1a668135c01d9a44f094b893d72852");
     assert_eq!(root, expected_root);
@@ -1062,7 +1060,7 @@ fn test_basic_vector_vec_bool_513_nil() {
 
 #[test]
 fn test_basic_vector_vec_bool_513_zero() {
-    let mut value = Vector::<bool, 513>::try_from(Vec::<bool>::from_iter([
+    let value = Vector::<bool, 513>::try_from(Vec::<bool>::from_iter([
         false, false, false, false, false, false, false, false, false, false, false, false, false,
         false, false, false, false, false, false, false, false, false, false, false, false, false,
         false, false, false, false, false, false, false, false, false, false, false, false, false,
@@ -1114,7 +1112,7 @@ fn test_basic_vector_vec_bool_513_zero() {
     let recovered_value: Vector<bool, 513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x9efde052aa15429fae05bad4d0b1d7c64da64d03d7a1854a588c2cb8430c0d30");
     assert_eq!(root, expected_root);
@@ -1158,9 +1156,8 @@ fn test_basic_vector_vec_bool_513_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_bool_5_max() {
-    let mut value =
-        Vector::<bool, 5>::try_from(Vec::<bool>::from_iter([true, true, true, true, true]))
-            .unwrap();
+    let value = Vector::<bool, 5>::try_from(Vec::<bool>::from_iter([true, true, true, true, true]))
+        .unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/basic_vector/valid/vec_bool_5_max/serialized.ssz_snappy",
@@ -1170,7 +1167,7 @@ fn test_basic_vector_vec_bool_5_max() {
     let recovered_value: Vector<bool, 5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0101010101000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -1228,7 +1225,7 @@ fn test_basic_vector_vec_bool_5_nil() {
 
 #[test]
 fn test_basic_vector_vec_bool_5_zero() {
-    let mut value =
+    let value =
         Vector::<bool, 5>::try_from(Vec::<bool>::from_iter([false, false, false, false, false]))
             .unwrap();
     let encoding = serialize(&value);
@@ -1240,7 +1237,7 @@ fn test_basic_vector_vec_bool_5_zero() {
     let recovered_value: Vector<bool, 5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -1284,7 +1281,7 @@ fn test_basic_vector_vec_bool_5_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_bool_8_max() {
-    let mut value = Vector::<bool, 8>::try_from(Vec::<bool>::from_iter([
+    let value = Vector::<bool, 8>::try_from(Vec::<bool>::from_iter([
         true, true, true, true, true, true, true, true,
     ]))
     .unwrap();
@@ -1297,7 +1294,7 @@ fn test_basic_vector_vec_bool_8_max() {
     let recovered_value: Vector<bool, 8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0101010101010101000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -1355,7 +1352,7 @@ fn test_basic_vector_vec_bool_8_nil() {
 
 #[test]
 fn test_basic_vector_vec_bool_8_zero() {
-    let mut value = Vector::<bool, 8>::try_from(Vec::<bool>::from_iter([
+    let value = Vector::<bool, 8>::try_from(Vec::<bool>::from_iter([
         false, false, false, false, false, false, false, false,
     ]))
     .unwrap();
@@ -1368,7 +1365,7 @@ fn test_basic_vector_vec_bool_8_zero() {
     let recovered_value: Vector<bool, 8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -1422,7 +1419,7 @@ fn test_basic_vector_vec_uint_128_0() {
 
 #[test]
 fn test_basic_vector_vec_uint_128_16_max() {
-    let mut value = Vector::<u128, 16>::try_from(Vec::<u128>::from_iter([
+    let value = Vector::<u128, 16>::try_from(Vec::<u128>::from_iter([
         340282366920938463463374607431768211455,
         340282366920938463463374607431768211455,
         340282366920938463463374607431768211455,
@@ -1450,7 +1447,7 @@ fn test_basic_vector_vec_uint_128_16_max() {
     let recovered_value: Vector<u128, 16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xbe1b7015ed50d7490a51f1b11dff804a4440775cc808b9cfd26157805c1f8e86");
     assert_eq!(root, expected_root);
@@ -1504,7 +1501,7 @@ fn test_basic_vector_vec_uint_128_16_nil() {
 
 #[test]
 fn test_basic_vector_vec_uint_128_16_random() {
-    let mut value = Vector::<u128, 16>::try_from(Vec::<u128>::from_iter([
+    let value = Vector::<u128, 16>::try_from(Vec::<u128>::from_iter([
         116865446011030976513736559583719158568,
         108209157078503776199170871747996541938,
         87702234582352091614673494037436374999,
@@ -1532,7 +1529,7 @@ fn test_basic_vector_vec_uint_128_16_random() {
     let recovered_value: Vector<u128, 16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x817667c88413a5134f4f42a1d0eb8e128cb658f3b2c3956360d32ca62f287f3f");
     assert_eq!(root, expected_root);
@@ -1572,7 +1569,7 @@ fn test_basic_vector_vec_uint_128_16_random_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_128_16_zero() {
-    let mut value = Vector::<u128, 16>::try_from(Vec::<u128>::from_iter([
+    let value = Vector::<u128, 16>::try_from(Vec::<u128>::from_iter([
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     ]))
     .unwrap();
@@ -1585,7 +1582,7 @@ fn test_basic_vector_vec_uint_128_16_zero() {
     let recovered_value: Vector<u128, 16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xc78009fdf07fc56a11f122370658a353aaa542ed63e44c4bc15ff4cd105ab33c");
     assert_eq!(root, expected_root);
@@ -1629,7 +1626,7 @@ fn test_basic_vector_vec_uint_128_16_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_128_1_max() {
-    let mut value = Vector::<u128, 1>::try_from(Vec::<u128>::from_iter([
+    let value = Vector::<u128, 1>::try_from(Vec::<u128>::from_iter([
         340282366920938463463374607431768211455,
     ]))
     .unwrap();
@@ -1642,7 +1639,7 @@ fn test_basic_vector_vec_uint_128_1_max() {
     let recovered_value: Vector<u128, 1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xffffffffffffffffffffffffffffffff00000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -1696,7 +1693,7 @@ fn test_basic_vector_vec_uint_128_1_nil() {
 
 #[test]
 fn test_basic_vector_vec_uint_128_1_random() {
-    let mut value = Vector::<u128, 1>::try_from(Vec::<u128>::from_iter([
+    let value = Vector::<u128, 1>::try_from(Vec::<u128>::from_iter([
         209794508200186098054846448654859096491,
     ]))
     .unwrap();
@@ -1709,7 +1706,7 @@ fn test_basic_vector_vec_uint_128_1_random() {
     let recovered_value: Vector<u128, 1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xabd1d3e35caaf8d7c91f1b63daf3d49d00000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -1749,7 +1746,7 @@ fn test_basic_vector_vec_uint_128_1_random_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_128_1_zero() {
-    let mut value = Vector::<u128, 1>::try_from(Vec::<u128>::from_iter([0])).unwrap();
+    let value = Vector::<u128, 1>::try_from(Vec::<u128>::from_iter([0])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/basic_vector/valid/vec_uint128_1_zero/serialized.ssz_snappy",
@@ -1759,7 +1756,7 @@ fn test_basic_vector_vec_uint_128_1_zero() {
     let recovered_value: Vector<u128, 1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -1803,7 +1800,7 @@ fn test_basic_vector_vec_uint_128_1_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_128_2_max() {
-    let mut value = Vector::<u128, 2>::try_from(Vec::<u128>::from_iter([
+    let value = Vector::<u128, 2>::try_from(Vec::<u128>::from_iter([
         340282366920938463463374607431768211455,
         340282366920938463463374607431768211455,
     ]))
@@ -1817,7 +1814,7 @@ fn test_basic_vector_vec_uint_128_2_max() {
     let recovered_value: Vector<u128, 2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
     assert_eq!(root, expected_root);
@@ -1871,7 +1868,7 @@ fn test_basic_vector_vec_uint_128_2_nil() {
 
 #[test]
 fn test_basic_vector_vec_uint_128_2_random() {
-    let mut value = Vector::<u128, 2>::try_from(Vec::<u128>::from_iter([
+    let value = Vector::<u128, 2>::try_from(Vec::<u128>::from_iter([
         293619838168840684930947284175392625045,
         264388153583386100657556026933098957077,
     ]))
@@ -1885,7 +1882,7 @@ fn test_basic_vector_vec_uint_128_2_random() {
     let recovered_value: Vector<u128, 2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x9551683c41029561557e6e42b51fe5dc15c90da19169c5900b46e5a5624ee7c6");
     assert_eq!(root, expected_root);
@@ -1925,7 +1922,7 @@ fn test_basic_vector_vec_uint_128_2_random_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_128_2_zero() {
-    let mut value = Vector::<u128, 2>::try_from(Vec::<u128>::from_iter([0, 0])).unwrap();
+    let value = Vector::<u128, 2>::try_from(Vec::<u128>::from_iter([0, 0])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/basic_vector/valid/vec_uint128_2_zero/serialized.ssz_snappy",
@@ -1935,7 +1932,7 @@ fn test_basic_vector_vec_uint_128_2_zero() {
     let recovered_value: Vector<u128, 2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -1979,7 +1976,7 @@ fn test_basic_vector_vec_uint_128_2_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_128_31_max() {
-    let mut value = Vector::<u128, 31>::try_from(Vec::<u128>::from_iter([
+    let value = Vector::<u128, 31>::try_from(Vec::<u128>::from_iter([
         340282366920938463463374607431768211455,
         340282366920938463463374607431768211455,
         340282366920938463463374607431768211455,
@@ -2022,7 +2019,7 @@ fn test_basic_vector_vec_uint_128_31_max() {
     let recovered_value: Vector<u128, 31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x661455692304dacd704fda4ac469deedd8783f5353c7120b35ceab4309536e81");
     assert_eq!(root, expected_root);
@@ -2076,7 +2073,7 @@ fn test_basic_vector_vec_uint_128_31_nil() {
 
 #[test]
 fn test_basic_vector_vec_uint_128_31_random() {
-    let mut value = Vector::<u128, 31>::try_from(Vec::<u128>::from_iter([
+    let value = Vector::<u128, 31>::try_from(Vec::<u128>::from_iter([
         322161099503949134246875383873042092581,
         48424120129033191202980611955490263589,
         83525771833522514138478832606095687392,
@@ -2119,7 +2116,7 @@ fn test_basic_vector_vec_uint_128_31_random() {
     let recovered_value: Vector<u128, 31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x6f8bfa11523cb7f78e6dabe9796ad0cb5b4730f6647c77164474985034ce1eba");
     assert_eq!(root, expected_root);
@@ -2159,7 +2156,7 @@ fn test_basic_vector_vec_uint_128_31_random_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_128_31_zero() {
-    let mut value = Vector::<u128, 31>::try_from(Vec::<u128>::from_iter([
+    let value = Vector::<u128, 31>::try_from(Vec::<u128>::from_iter([
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     ]))
     .unwrap();
@@ -2172,7 +2169,7 @@ fn test_basic_vector_vec_uint_128_31_zero() {
     let recovered_value: Vector<u128, 31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x536d98837f2dd165a55d5eeae91485954472d56f246df256bf3cae19352a123c");
     assert_eq!(root, expected_root);
@@ -2216,7 +2213,7 @@ fn test_basic_vector_vec_uint_128_31_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_128_3_max() {
-    let mut value = Vector::<u128, 3>::try_from(Vec::<u128>::from_iter([
+    let value = Vector::<u128, 3>::try_from(Vec::<u128>::from_iter([
         340282366920938463463374607431768211455,
         340282366920938463463374607431768211455,
         340282366920938463463374607431768211455,
@@ -2231,7 +2228,7 @@ fn test_basic_vector_vec_uint_128_3_max() {
     let recovered_value: Vector<u128, 3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x1e3915ef9ca4ed8619d472b72fb1833448756054b4de9acb439da54dff7166aa");
     assert_eq!(root, expected_root);
@@ -2285,7 +2282,7 @@ fn test_basic_vector_vec_uint_128_3_nil() {
 
 #[test]
 fn test_basic_vector_vec_uint_128_3_random() {
-    let mut value = Vector::<u128, 3>::try_from(Vec::<u128>::from_iter([
+    let value = Vector::<u128, 3>::try_from(Vec::<u128>::from_iter([
         220301989141709271334326095341414922102,
         210235080945710533958926333282570767995,
         38717160196772117737433576948282568669,
@@ -2300,7 +2297,7 @@ fn test_basic_vector_vec_uint_128_3_random() {
     let recovered_value: Vector<u128, 3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x5376f444f73d42d4319e96d18c1d78ffab3f12464280dee8cf1df519ff50d628");
     assert_eq!(root, expected_root);
@@ -2340,7 +2337,7 @@ fn test_basic_vector_vec_uint_128_3_random_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_128_3_zero() {
-    let mut value = Vector::<u128, 3>::try_from(Vec::<u128>::from_iter([0, 0, 0])).unwrap();
+    let value = Vector::<u128, 3>::try_from(Vec::<u128>::from_iter([0, 0, 0])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/basic_vector/valid/vec_uint128_3_zero/serialized.ssz_snappy",
@@ -2350,7 +2347,7 @@ fn test_basic_vector_vec_uint_128_3_zero() {
     let recovered_value: Vector<u128, 3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -2394,7 +2391,7 @@ fn test_basic_vector_vec_uint_128_3_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_128_4_max() {
-    let mut value = Vector::<u128, 4>::try_from(Vec::<u128>::from_iter([
+    let value = Vector::<u128, 4>::try_from(Vec::<u128>::from_iter([
         340282366920938463463374607431768211455,
         340282366920938463463374607431768211455,
         340282366920938463463374607431768211455,
@@ -2410,7 +2407,7 @@ fn test_basic_vector_vec_uint_128_4_max() {
     let recovered_value: Vector<u128, 4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x8667e718294e9e0df1d30600ba3eeb201f764aad2dad72748643e4a285e1d1f7");
     assert_eq!(root, expected_root);
@@ -2464,7 +2461,7 @@ fn test_basic_vector_vec_uint_128_4_nil() {
 
 #[test]
 fn test_basic_vector_vec_uint_128_4_random() {
-    let mut value = Vector::<u128, 4>::try_from(Vec::<u128>::from_iter([
+    let value = Vector::<u128, 4>::try_from(Vec::<u128>::from_iter([
         131085251763681703650210983225134279210,
         204149994827974013891189432256283029251,
         138314451233364434501509339736780133583,
@@ -2480,7 +2477,7 @@ fn test_basic_vector_vec_uint_128_4_random() {
     let recovered_value: Vector<u128, 4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xe7b9070421c5a3414fa58f06ad8bdf6f4a8e8464fe1dc5b1214aab2db1662e06");
     assert_eq!(root, expected_root);
@@ -2520,7 +2517,7 @@ fn test_basic_vector_vec_uint_128_4_random_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_128_4_zero() {
-    let mut value = Vector::<u128, 4>::try_from(Vec::<u128>::from_iter([0, 0, 0, 0])).unwrap();
+    let value = Vector::<u128, 4>::try_from(Vec::<u128>::from_iter([0, 0, 0, 0])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/basic_vector/valid/vec_uint128_4_zero/serialized.ssz_snappy",
@@ -2530,7 +2527,7 @@ fn test_basic_vector_vec_uint_128_4_zero() {
     let recovered_value: Vector<u128, 4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -2574,7 +2571,7 @@ fn test_basic_vector_vec_uint_128_4_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_128_512_max() {
-    let mut value = Vector::<u128, 512>::try_from(Vec::<u128>::from_iter([
+    let value = Vector::<u128, 512>::try_from(Vec::<u128>::from_iter([
         340282366920938463463374607431768211455,
         340282366920938463463374607431768211455,
         340282366920938463463374607431768211455,
@@ -3098,7 +3095,7 @@ fn test_basic_vector_vec_uint_128_512_max() {
     let recovered_value: Vector<u128, 512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xd13fb49c7c7e17c33d7bfb88c3e3d674e602b53315c769a4b9f053ffba656cc3");
     assert_eq!(root, expected_root);
@@ -3152,7 +3149,7 @@ fn test_basic_vector_vec_uint_128_512_nil() {
 
 #[test]
 fn test_basic_vector_vec_uint_128_512_random() {
-    let mut value = Vector::<u128, 512>::try_from(Vec::<u128>::from_iter([
+    let value = Vector::<u128, 512>::try_from(Vec::<u128>::from_iter([
         26828682623905485853721589978864387876,
         45362230084934828632880963081896644001,
         247417070223805448009596661148965288679,
@@ -3676,7 +3673,7 @@ fn test_basic_vector_vec_uint_128_512_random() {
     let recovered_value: Vector<u128, 512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xa70c5dc4851c46df26580a4d719f454113421b5b078b1af7b8f6435f8d61b304");
     assert_eq!(root, expected_root);
@@ -3716,7 +3713,7 @@ fn test_basic_vector_vec_uint_128_512_random_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_128_512_zero() {
-    let mut value = Vector::<u128, 512>::try_from(Vec::<u128>::from_iter([
+    let value = Vector::<u128, 512>::try_from(Vec::<u128>::from_iter([
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -3746,7 +3743,7 @@ fn test_basic_vector_vec_uint_128_512_zero() {
     let recovered_value: Vector<u128, 512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x26846476fd5fc54a5d43385167c95144f2643f533cc85bb9d16b782f8d7db193");
     assert_eq!(root, expected_root);
@@ -3786,7 +3783,7 @@ fn test_basic_vector_vec_uint_128_512_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_128_513_max() {
-    let mut value = Vector::<u128, 513>::try_from(Vec::<u128>::from_iter([
+    let value = Vector::<u128, 513>::try_from(Vec::<u128>::from_iter([
         340282366920938463463374607431768211455,
         340282366920938463463374607431768211455,
         340282366920938463463374607431768211455,
@@ -4311,7 +4308,7 @@ fn test_basic_vector_vec_uint_128_513_max() {
     let recovered_value: Vector<u128, 513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x71b09f3b6e5e978c55a3e8e88640e9abbfe68c41e61e96424cffa42b63bfa413");
     assert_eq!(root, expected_root);
@@ -4365,7 +4362,7 @@ fn test_basic_vector_vec_uint_128_513_nil() {
 
 #[test]
 fn test_basic_vector_vec_uint_128_513_random() {
-    let mut value = Vector::<u128, 513>::try_from(Vec::<u128>::from_iter([
+    let value = Vector::<u128, 513>::try_from(Vec::<u128>::from_iter([
         34806233895606943316594477386264063388,
         269482665842274191832954812547223680643,
         98566888497380199723262118438348948905,
@@ -4890,7 +4887,7 @@ fn test_basic_vector_vec_uint_128_513_random() {
     let recovered_value: Vector<u128, 513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x7c9e8b3a007dbdcf573b837b5ace3e186a390e605306d95a3c9c4fc893b62088");
     assert_eq!(root, expected_root);
@@ -4930,7 +4927,7 @@ fn test_basic_vector_vec_uint_128_513_random_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_128_513_zero() {
-    let mut value = Vector::<u128, 513>::try_from(Vec::<u128>::from_iter([
+    let value = Vector::<u128, 513>::try_from(Vec::<u128>::from_iter([
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -4960,7 +4957,7 @@ fn test_basic_vector_vec_uint_128_513_zero() {
     let recovered_value: Vector<u128, 513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x506d86582d252405b840018792cad2bf1259f1ef5aa5f887e13cb2f0094f51e1");
     assert_eq!(root, expected_root);
@@ -5000,7 +4997,7 @@ fn test_basic_vector_vec_uint_128_513_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_128_5_max() {
-    let mut value = Vector::<u128, 5>::try_from(Vec::<u128>::from_iter([
+    let value = Vector::<u128, 5>::try_from(Vec::<u128>::from_iter([
         340282366920938463463374607431768211455,
         340282366920938463463374607431768211455,
         340282366920938463463374607431768211455,
@@ -5017,7 +5014,7 @@ fn test_basic_vector_vec_uint_128_5_max() {
     let recovered_value: Vector<u128, 5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x42b2994e8f77b7cc4b05fe01a2d6570ab7d29be54e434582425697ee8cd8f2c2");
     assert_eq!(root, expected_root);
@@ -5071,7 +5068,7 @@ fn test_basic_vector_vec_uint_128_5_nil() {
 
 #[test]
 fn test_basic_vector_vec_uint_128_5_random() {
-    let mut value = Vector::<u128, 5>::try_from(Vec::<u128>::from_iter([
+    let value = Vector::<u128, 5>::try_from(Vec::<u128>::from_iter([
         194578830033788736352569855138204668708,
         222404791245710801707639009374583541271,
         300921627290141104382250227469409620613,
@@ -5088,7 +5085,7 @@ fn test_basic_vector_vec_uint_128_5_random() {
     let recovered_value: Vector<u128, 5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x3783f4ecb6a705af305039d2f104b57616a40fd279144e6723358ca561a22a51");
     assert_eq!(root, expected_root);
@@ -5128,7 +5125,7 @@ fn test_basic_vector_vec_uint_128_5_random_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_128_5_zero() {
-    let mut value = Vector::<u128, 5>::try_from(Vec::<u128>::from_iter([0, 0, 0, 0, 0])).unwrap();
+    let value = Vector::<u128, 5>::try_from(Vec::<u128>::from_iter([0, 0, 0, 0, 0])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/basic_vector/valid/vec_uint128_5_zero/serialized.ssz_snappy",
@@ -5138,7 +5135,7 @@ fn test_basic_vector_vec_uint_128_5_zero() {
     let recovered_value: Vector<u128, 5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xdb56114e00fdd4c1f85c892bf35ac9a89289aaecb1ebd0a96cde606a748b5d71");
     assert_eq!(root, expected_root);
@@ -5182,7 +5179,7 @@ fn test_basic_vector_vec_uint_128_5_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_128_8_max() {
-    let mut value = Vector::<u128, 8>::try_from(Vec::<u128>::from_iter([
+    let value = Vector::<u128, 8>::try_from(Vec::<u128>::from_iter([
         340282366920938463463374607431768211455,
         340282366920938463463374607431768211455,
         340282366920938463463374607431768211455,
@@ -5202,7 +5199,7 @@ fn test_basic_vector_vec_uint_128_8_max() {
     let recovered_value: Vector<u128, 8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x375d6c7b280a1e30f968db1d948da0f977bf9139b0d5516761ac874700208aba");
     assert_eq!(root, expected_root);
@@ -5256,7 +5253,7 @@ fn test_basic_vector_vec_uint_128_8_nil() {
 
 #[test]
 fn test_basic_vector_vec_uint_128_8_random() {
-    let mut value = Vector::<u128, 8>::try_from(Vec::<u128>::from_iter([
+    let value = Vector::<u128, 8>::try_from(Vec::<u128>::from_iter([
         50419731819167183509591636238702702250,
         243160052554941226771061620517961416402,
         132077915854571525015052582449039997777,
@@ -5276,7 +5273,7 @@ fn test_basic_vector_vec_uint_128_8_random() {
     let recovered_value: Vector<u128, 8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x5b77a9c4d86ba3e9079f98093f5e6da648e81f10f89f46c1fcab2a4c779c0363");
     assert_eq!(root, expected_root);
@@ -5316,7 +5313,7 @@ fn test_basic_vector_vec_uint_128_8_random_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_128_8_zero() {
-    let mut value =
+    let value =
         Vector::<u128, 8>::try_from(Vec::<u128>::from_iter([0, 0, 0, 0, 0, 0, 0, 0])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -5327,7 +5324,7 @@ fn test_basic_vector_vec_uint_128_8_zero() {
     let recovered_value: Vector<u128, 8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xdb56114e00fdd4c1f85c892bf35ac9a89289aaecb1ebd0a96cde606a748b5d71");
     assert_eq!(root, expected_root);
@@ -5381,7 +5378,7 @@ fn test_basic_vector_vec_uint_16_0() {
 
 #[test]
 fn test_basic_vector_vec_uint_16_16_max() {
-    let mut value = Vector::<u16, 16>::try_from(Vec::<u16>::from_iter([
+    let value = Vector::<u16, 16>::try_from(Vec::<u16>::from_iter([
         65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
         65535, 65535, 65535,
     ]))
@@ -5395,7 +5392,7 @@ fn test_basic_vector_vec_uint_16_16_max() {
     let recovered_value: Vector<u16, 16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
     assert_eq!(root, expected_root);
@@ -5449,7 +5446,7 @@ fn test_basic_vector_vec_uint_16_16_nil() {
 
 #[test]
 fn test_basic_vector_vec_uint_16_16_random() {
-    let mut value = Vector::<u16, 16>::try_from(Vec::<u16>::from_iter([
+    let value = Vector::<u16, 16>::try_from(Vec::<u16>::from_iter([
         14966, 37668, 46928, 65487, 22250, 24796, 7043, 49742, 46495, 44245, 5372, 46169, 36046,
         60670, 29615, 59474,
     ]))
@@ -5463,7 +5460,7 @@ fn test_basic_vector_vec_uint_16_16_random() {
     let recovered_value: Vector<u16, 16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x763a249350b7cfffea56dc60831b4ec29fb5d5acfc1459b4ce8cfeecaf7352e8");
     assert_eq!(root, expected_root);
@@ -5503,7 +5500,7 @@ fn test_basic_vector_vec_uint_16_16_random_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_16_16_zero() {
-    let mut value = Vector::<u16, 16>::try_from(Vec::<u16>::from_iter([
+    let value = Vector::<u16, 16>::try_from(Vec::<u16>::from_iter([
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     ]))
     .unwrap();
@@ -5516,7 +5513,7 @@ fn test_basic_vector_vec_uint_16_16_zero() {
     let recovered_value: Vector<u16, 16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -5560,7 +5557,7 @@ fn test_basic_vector_vec_uint_16_16_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_16_1_max() {
-    let mut value = Vector::<u16, 1>::try_from(Vec::<u16>::from_iter([65535])).unwrap();
+    let value = Vector::<u16, 1>::try_from(Vec::<u16>::from_iter([65535])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/basic_vector/valid/vec_uint16_1_max/serialized.ssz_snappy",
@@ -5570,7 +5567,7 @@ fn test_basic_vector_vec_uint_16_1_max() {
     let recovered_value: Vector<u16, 1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xffff000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -5624,7 +5621,7 @@ fn test_basic_vector_vec_uint_16_1_nil() {
 
 #[test]
 fn test_basic_vector_vec_uint_16_1_random() {
-    let mut value = Vector::<u16, 1>::try_from(Vec::<u16>::from_iter([58671])).unwrap();
+    let value = Vector::<u16, 1>::try_from(Vec::<u16>::from_iter([58671])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/basic_vector/valid/vec_uint16_1_random/serialized.ssz_snappy",
@@ -5634,7 +5631,7 @@ fn test_basic_vector_vec_uint_16_1_random() {
     let recovered_value: Vector<u16, 1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x2fe5000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -5678,7 +5675,7 @@ fn test_basic_vector_vec_uint_16_1_random_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_16_1_zero() {
-    let mut value = Vector::<u16, 1>::try_from(Vec::<u16>::from_iter([0])).unwrap();
+    let value = Vector::<u16, 1>::try_from(Vec::<u16>::from_iter([0])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/basic_vector/valid/vec_uint16_1_zero/serialized.ssz_snappy",
@@ -5688,7 +5685,7 @@ fn test_basic_vector_vec_uint_16_1_zero() {
     let recovered_value: Vector<u16, 1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -5732,7 +5729,7 @@ fn test_basic_vector_vec_uint_16_1_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_16_2_max() {
-    let mut value = Vector::<u16, 2>::try_from(Vec::<u16>::from_iter([65535, 65535])).unwrap();
+    let value = Vector::<u16, 2>::try_from(Vec::<u16>::from_iter([65535, 65535])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/basic_vector/valid/vec_uint16_2_max/serialized.ssz_snappy",
@@ -5742,7 +5739,7 @@ fn test_basic_vector_vec_uint_16_2_max() {
     let recovered_value: Vector<u16, 2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xffffffff00000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -5796,7 +5793,7 @@ fn test_basic_vector_vec_uint_16_2_nil() {
 
 #[test]
 fn test_basic_vector_vec_uint_16_2_random() {
-    let mut value = Vector::<u16, 2>::try_from(Vec::<u16>::from_iter([12188, 36886])).unwrap();
+    let value = Vector::<u16, 2>::try_from(Vec::<u16>::from_iter([12188, 36886])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/basic_vector/valid/vec_uint16_2_random/serialized.ssz_snappy",
@@ -5806,7 +5803,7 @@ fn test_basic_vector_vec_uint_16_2_random() {
     let recovered_value: Vector<u16, 2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x9c2f169000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -5850,7 +5847,7 @@ fn test_basic_vector_vec_uint_16_2_random_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_16_2_zero() {
-    let mut value = Vector::<u16, 2>::try_from(Vec::<u16>::from_iter([0, 0])).unwrap();
+    let value = Vector::<u16, 2>::try_from(Vec::<u16>::from_iter([0, 0])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/basic_vector/valid/vec_uint16_2_zero/serialized.ssz_snappy",
@@ -5860,7 +5857,7 @@ fn test_basic_vector_vec_uint_16_2_zero() {
     let recovered_value: Vector<u16, 2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -5904,7 +5901,7 @@ fn test_basic_vector_vec_uint_16_2_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_16_31_max() {
-    let mut value = Vector::<u16, 31>::try_from(Vec::<u16>::from_iter([
+    let value = Vector::<u16, 31>::try_from(Vec::<u16>::from_iter([
         65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
         65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
         65535, 65535, 65535, 65535, 65535,
@@ -5919,7 +5916,7 @@ fn test_basic_vector_vec_uint_16_31_max() {
     let recovered_value: Vector<u16, 31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x43cbd26c37dcff8448ce8896f9b5e553a1047de0c59ec3b477decefbdea9c74b");
     assert_eq!(root, expected_root);
@@ -5973,7 +5970,7 @@ fn test_basic_vector_vec_uint_16_31_nil() {
 
 #[test]
 fn test_basic_vector_vec_uint_16_31_random() {
-    let mut value = Vector::<u16, 31>::try_from(Vec::<u16>::from_iter([
+    let value = Vector::<u16, 31>::try_from(Vec::<u16>::from_iter([
         2630, 4376, 65427, 13583, 41975, 15842, 27686, 33957, 45114, 56180, 24895, 4175, 40381,
         32830, 48421, 52207, 58611, 41821, 31373, 23853, 55119, 1957, 34877, 62496, 37311, 40303,
         44876, 36839, 47492, 53209, 24055,
@@ -5988,7 +5985,7 @@ fn test_basic_vector_vec_uint_16_31_random() {
     let recovered_value: Vector<u16, 31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x29fab6cb24858519d6e8d3af2fdac7ec9fce5c08e978fb1a3cdb3fad6fe88f7f");
     assert_eq!(root, expected_root);
@@ -6028,7 +6025,7 @@ fn test_basic_vector_vec_uint_16_31_random_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_16_31_zero() {
-    let mut value = Vector::<u16, 31>::try_from(Vec::<u16>::from_iter([
+    let value = Vector::<u16, 31>::try_from(Vec::<u16>::from_iter([
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     ]))
     .unwrap();
@@ -6041,7 +6038,7 @@ fn test_basic_vector_vec_uint_16_31_zero() {
     let recovered_value: Vector<u16, 31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -6085,8 +6082,7 @@ fn test_basic_vector_vec_uint_16_31_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_16_3_max() {
-    let mut value =
-        Vector::<u16, 3>::try_from(Vec::<u16>::from_iter([65535, 65535, 65535])).unwrap();
+    let value = Vector::<u16, 3>::try_from(Vec::<u16>::from_iter([65535, 65535, 65535])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/basic_vector/valid/vec_uint16_3_max/serialized.ssz_snappy",
@@ -6096,7 +6092,7 @@ fn test_basic_vector_vec_uint_16_3_max() {
     let recovered_value: Vector<u16, 3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xffffffffffff0000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -6150,8 +6146,7 @@ fn test_basic_vector_vec_uint_16_3_nil() {
 
 #[test]
 fn test_basic_vector_vec_uint_16_3_random() {
-    let mut value =
-        Vector::<u16, 3>::try_from(Vec::<u16>::from_iter([55998, 58650, 32471])).unwrap();
+    let value = Vector::<u16, 3>::try_from(Vec::<u16>::from_iter([55998, 58650, 32471])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/basic_vector/valid/vec_uint16_3_random/serialized.ssz_snappy",
@@ -6161,7 +6156,7 @@ fn test_basic_vector_vec_uint_16_3_random() {
     let recovered_value: Vector<u16, 3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xbeda1ae5d77e0000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -6205,7 +6200,7 @@ fn test_basic_vector_vec_uint_16_3_random_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_16_3_zero() {
-    let mut value = Vector::<u16, 3>::try_from(Vec::<u16>::from_iter([0, 0, 0])).unwrap();
+    let value = Vector::<u16, 3>::try_from(Vec::<u16>::from_iter([0, 0, 0])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/basic_vector/valid/vec_uint16_3_zero/serialized.ssz_snappy",
@@ -6215,7 +6210,7 @@ fn test_basic_vector_vec_uint_16_3_zero() {
     let recovered_value: Vector<u16, 3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -6259,7 +6254,7 @@ fn test_basic_vector_vec_uint_16_3_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_16_4_max() {
-    let mut value =
+    let value =
         Vector::<u16, 4>::try_from(Vec::<u16>::from_iter([65535, 65535, 65535, 65535])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -6270,7 +6265,7 @@ fn test_basic_vector_vec_uint_16_4_max() {
     let recovered_value: Vector<u16, 4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xffffffffffffffff000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -6324,7 +6319,7 @@ fn test_basic_vector_vec_uint_16_4_nil() {
 
 #[test]
 fn test_basic_vector_vec_uint_16_4_random() {
-    let mut value =
+    let value =
         Vector::<u16, 4>::try_from(Vec::<u16>::from_iter([15417, 28067, 51352, 59311])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -6335,7 +6330,7 @@ fn test_basic_vector_vec_uint_16_4_random() {
     let recovered_value: Vector<u16, 4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x393ca36d98c8afe7000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -6379,7 +6374,7 @@ fn test_basic_vector_vec_uint_16_4_random_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_16_4_zero() {
-    let mut value = Vector::<u16, 4>::try_from(Vec::<u16>::from_iter([0, 0, 0, 0])).unwrap();
+    let value = Vector::<u16, 4>::try_from(Vec::<u16>::from_iter([0, 0, 0, 0])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/basic_vector/valid/vec_uint16_4_zero/serialized.ssz_snappy",
@@ -6389,7 +6384,7 @@ fn test_basic_vector_vec_uint_16_4_zero() {
     let recovered_value: Vector<u16, 4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -6433,7 +6428,7 @@ fn test_basic_vector_vec_uint_16_4_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_16_512_max() {
-    let mut value = Vector::<u16, 512>::try_from(Vec::<u16>::from_iter([
+    let value = Vector::<u16, 512>::try_from(Vec::<u16>::from_iter([
         65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
         65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
         65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
@@ -6485,7 +6480,7 @@ fn test_basic_vector_vec_uint_16_512_max() {
     let recovered_value: Vector<u16, 512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xd3313908d702519e871c34a2b5f7d84108966149289a16d7795ef15ebaa42b25");
     assert_eq!(root, expected_root);
@@ -6539,7 +6534,7 @@ fn test_basic_vector_vec_uint_16_512_nil() {
 
 #[test]
 fn test_basic_vector_vec_uint_16_512_random() {
-    let mut value = Vector::<u16, 512>::try_from(Vec::<u16>::from_iter([
+    let value = Vector::<u16, 512>::try_from(Vec::<u16>::from_iter([
         39340, 21094, 12815, 18079, 3546, 9133, 45047, 41320, 3878, 13753, 38525, 64568, 43355,
         62649, 55650, 30889, 7989, 16810, 53928, 52810, 54272, 34111, 43130, 14634, 55804, 24247,
         2549, 37573, 53039, 1273, 63106, 10081, 35901, 22063, 65529, 36398, 22557, 6548, 49942,
@@ -6591,7 +6586,7 @@ fn test_basic_vector_vec_uint_16_512_random() {
     let recovered_value: Vector<u16, 512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x01f2508b1eb51699811c789fd266764f6c2831cbbfd862c91b860066149970e9");
     assert_eq!(root, expected_root);
@@ -6631,7 +6626,7 @@ fn test_basic_vector_vec_uint_16_512_random_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_16_512_zero() {
-    let mut value = Vector::<u16, 512>::try_from(Vec::<u16>::from_iter([
+    let value = Vector::<u16, 512>::try_from(Vec::<u16>::from_iter([
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -6661,7 +6656,7 @@ fn test_basic_vector_vec_uint_16_512_zero() {
     let recovered_value: Vector<u16, 512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x9efde052aa15429fae05bad4d0b1d7c64da64d03d7a1854a588c2cb8430c0d30");
     assert_eq!(root, expected_root);
@@ -6705,7 +6700,7 @@ fn test_basic_vector_vec_uint_16_512_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_16_513_max() {
-    let mut value = Vector::<u16, 513>::try_from(Vec::<u16>::from_iter([
+    let value = Vector::<u16, 513>::try_from(Vec::<u16>::from_iter([
         65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
         65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
         65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
@@ -6757,7 +6752,7 @@ fn test_basic_vector_vec_uint_16_513_max() {
     let recovered_value: Vector<u16, 513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x193411b011bc1acbf600803324bc5dc359acef14c1be285ef7565186c0ea9b10");
     assert_eq!(root, expected_root);
@@ -6811,7 +6806,7 @@ fn test_basic_vector_vec_uint_16_513_nil() {
 
 #[test]
 fn test_basic_vector_vec_uint_16_513_random() {
-    let mut value = Vector::<u16, 513>::try_from(Vec::<u16>::from_iter([
+    let value = Vector::<u16, 513>::try_from(Vec::<u16>::from_iter([
         27185, 40496, 45588, 22785, 5755, 5950, 14234, 16151, 23366, 48189, 28838, 47431, 22937,
         44687, 9960, 18008, 43796, 16472, 40344, 6307, 60750, 42176, 48076, 3047, 34291, 53364,
         5934, 35808, 39627, 16700, 61818, 17790, 2074, 12801, 14876, 34651, 31986, 54424, 35627,
@@ -6863,7 +6858,7 @@ fn test_basic_vector_vec_uint_16_513_random() {
     let recovered_value: Vector<u16, 513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x188c519f6d8f57d2cc1232b7ad085ed707cec9537fb3912ffa095423dc614dea");
     assert_eq!(root, expected_root);
@@ -6903,7 +6898,7 @@ fn test_basic_vector_vec_uint_16_513_random_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_16_513_zero() {
-    let mut value = Vector::<u16, 513>::try_from(Vec::<u16>::from_iter([
+    let value = Vector::<u16, 513>::try_from(Vec::<u16>::from_iter([
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -6933,7 +6928,7 @@ fn test_basic_vector_vec_uint_16_513_zero() {
     let recovered_value: Vector<u16, 513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xd88ddfeed400a8755596b21942c1497e114c302e6118290f91e6772976041fa1");
     assert_eq!(root, expected_root);
@@ -6977,7 +6972,7 @@ fn test_basic_vector_vec_uint_16_513_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_16_5_max() {
-    let mut value =
+    let value =
         Vector::<u16, 5>::try_from(Vec::<u16>::from_iter([65535, 65535, 65535, 65535, 65535]))
             .unwrap();
     let encoding = serialize(&value);
@@ -6989,7 +6984,7 @@ fn test_basic_vector_vec_uint_16_5_max() {
     let recovered_value: Vector<u16, 5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xffffffffffffffffffff00000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -7043,7 +7038,7 @@ fn test_basic_vector_vec_uint_16_5_nil() {
 
 #[test]
 fn test_basic_vector_vec_uint_16_5_random() {
-    let mut value =
+    let value =
         Vector::<u16, 5>::try_from(Vec::<u16>::from_iter([35919, 34593, 14706, 39574, 53868]))
             .unwrap();
     let encoding = serialize(&value);
@@ -7055,7 +7050,7 @@ fn test_basic_vector_vec_uint_16_5_random() {
     let recovered_value: Vector<u16, 5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x4f8c21877239969a6cd200000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -7099,7 +7094,7 @@ fn test_basic_vector_vec_uint_16_5_random_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_16_5_zero() {
-    let mut value = Vector::<u16, 5>::try_from(Vec::<u16>::from_iter([0, 0, 0, 0, 0])).unwrap();
+    let value = Vector::<u16, 5>::try_from(Vec::<u16>::from_iter([0, 0, 0, 0, 0])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/basic_vector/valid/vec_uint16_5_zero/serialized.ssz_snappy",
@@ -7109,7 +7104,7 @@ fn test_basic_vector_vec_uint_16_5_zero() {
     let recovered_value: Vector<u16, 5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -7153,7 +7148,7 @@ fn test_basic_vector_vec_uint_16_5_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_16_8_max() {
-    let mut value = Vector::<u16, 8>::try_from(Vec::<u16>::from_iter([
+    let value = Vector::<u16, 8>::try_from(Vec::<u16>::from_iter([
         65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
     ]))
     .unwrap();
@@ -7166,7 +7161,7 @@ fn test_basic_vector_vec_uint_16_8_max() {
     let recovered_value: Vector<u16, 8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xffffffffffffffffffffffffffffffff00000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -7220,7 +7215,7 @@ fn test_basic_vector_vec_uint_16_8_nil() {
 
 #[test]
 fn test_basic_vector_vec_uint_16_8_random() {
-    let mut value = Vector::<u16, 8>::try_from(Vec::<u16>::from_iter([
+    let value = Vector::<u16, 8>::try_from(Vec::<u16>::from_iter([
         48757, 12920, 33149, 59406, 48754, 39786, 12312, 58318,
     ]))
     .unwrap();
@@ -7233,7 +7228,7 @@ fn test_basic_vector_vec_uint_16_8_random() {
     let recovered_value: Vector<u16, 8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x75be78327d810ee872be6a9b1830cee300000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -7277,7 +7272,7 @@ fn test_basic_vector_vec_uint_16_8_random_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_16_8_zero() {
-    let mut value =
+    let value =
         Vector::<u16, 8>::try_from(Vec::<u16>::from_iter([0, 0, 0, 0, 0, 0, 0, 0])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -7288,7 +7283,7 @@ fn test_basic_vector_vec_uint_16_8_zero() {
     let recovered_value: Vector<u16, 8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -7342,7 +7337,7 @@ fn test_basic_vector_vec_uint_256_0() {
 
 #[test]
 fn test_basic_vector_vec_uint_256_16_max() {
-    let mut value = Vector::<U256, 16>::try_from(Vec::<U256>::from_iter([
+    let value = Vector::<U256, 16>::try_from(Vec::<U256>::from_iter([
         U256::try_from_le_slice(
             Vec::<u8>::from_iter([
                 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
@@ -7482,7 +7477,7 @@ fn test_basic_vector_vec_uint_256_16_max() {
     let recovered_value: Vector<U256, 16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x006eed26f731a68917853879507d9fa9f4044f7af999f9df535fac29715db555");
     assert_eq!(root, expected_root);
@@ -7536,7 +7531,7 @@ fn test_basic_vector_vec_uint_256_16_nil() {
 
 #[test]
 fn test_basic_vector_vec_uint_256_16_random() {
-    let mut value = Vector::<U256, 16>::try_from(Vec::<U256>::from_iter([
+    let value = Vector::<U256, 16>::try_from(Vec::<U256>::from_iter([
         U256::try_from_le_slice(
             Vec::<u8>::from_iter([
                 240, 52, 157, 62, 33, 82, 186, 76, 43, 156, 161, 241, 59, 31, 225, 79, 247, 97,
@@ -7676,7 +7671,7 @@ fn test_basic_vector_vec_uint_256_16_random() {
     let recovered_value: Vector<U256, 16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x1acf6f6a33e7a6642bf9f60d5c829ca9f09390bf30663f50ef1424796f582057");
     assert_eq!(root, expected_root);
@@ -7716,7 +7711,7 @@ fn test_basic_vector_vec_uint_256_16_random_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_256_16_zero() {
-    let mut value = Vector::<U256, 16>::try_from(Vec::<U256>::from_iter([
+    let value = Vector::<U256, 16>::try_from(Vec::<U256>::from_iter([
         U256::try_from_le_slice(
             Vec::<u8>::from_iter([
                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -7856,7 +7851,7 @@ fn test_basic_vector_vec_uint_256_16_zero() {
     let recovered_value: Vector<U256, 16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x536d98837f2dd165a55d5eeae91485954472d56f246df256bf3cae19352a123c");
     assert_eq!(root, expected_root);
@@ -7900,7 +7895,7 @@ fn test_basic_vector_vec_uint_256_16_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_256_1_max() {
-    let mut value = Vector::<U256, 1>::try_from(Vec::<U256>::from_iter([U256::try_from_le_slice(
+    let value = Vector::<U256, 1>::try_from(Vec::<U256>::from_iter([U256::try_from_le_slice(
         Vec::<u8>::from_iter([
             255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
             255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
@@ -7918,7 +7913,7 @@ fn test_basic_vector_vec_uint_256_1_max() {
     let recovered_value: Vector<U256, 1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
     assert_eq!(root, expected_root);
@@ -7972,7 +7967,7 @@ fn test_basic_vector_vec_uint_256_1_nil() {
 
 #[test]
 fn test_basic_vector_vec_uint_256_1_random() {
-    let mut value = Vector::<U256, 1>::try_from(Vec::<U256>::from_iter([U256::try_from_le_slice(
+    let value = Vector::<U256, 1>::try_from(Vec::<U256>::from_iter([U256::try_from_le_slice(
         Vec::<u8>::from_iter([
             23, 198, 217, 240, 65, 96, 243, 95, 206, 232, 214, 26, 230, 80, 25, 35, 116, 138, 185,
             248, 165, 147, 63, 252, 41, 25, 209, 95, 73, 233, 26, 244,
@@ -7990,7 +7985,7 @@ fn test_basic_vector_vec_uint_256_1_random() {
     let recovered_value: Vector<U256, 1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x17c6d9f04160f35fcee8d61ae6501923748ab9f8a5933ffc2919d15f49e91af4");
     assert_eq!(root, expected_root);
@@ -8030,7 +8025,7 @@ fn test_basic_vector_vec_uint_256_1_random_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_256_1_zero() {
-    let mut value = Vector::<U256, 1>::try_from(Vec::<U256>::from_iter([U256::try_from_le_slice(
+    let value = Vector::<U256, 1>::try_from(Vec::<U256>::from_iter([U256::try_from_le_slice(
         Vec::<u8>::from_iter([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0,
@@ -8048,7 +8043,7 @@ fn test_basic_vector_vec_uint_256_1_zero() {
     let recovered_value: Vector<U256, 1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -8092,7 +8087,7 @@ fn test_basic_vector_vec_uint_256_1_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_256_2_max() {
-    let mut value = Vector::<U256, 2>::try_from(Vec::<U256>::from_iter([
+    let value = Vector::<U256, 2>::try_from(Vec::<U256>::from_iter([
         U256::try_from_le_slice(
             Vec::<u8>::from_iter([
                 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
@@ -8120,7 +8115,7 @@ fn test_basic_vector_vec_uint_256_2_max() {
     let recovered_value: Vector<U256, 2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x8667e718294e9e0df1d30600ba3eeb201f764aad2dad72748643e4a285e1d1f7");
     assert_eq!(root, expected_root);
@@ -8174,7 +8169,7 @@ fn test_basic_vector_vec_uint_256_2_nil() {
 
 #[test]
 fn test_basic_vector_vec_uint_256_2_random() {
-    let mut value = Vector::<U256, 2>::try_from(Vec::<U256>::from_iter([
+    let value = Vector::<U256, 2>::try_from(Vec::<U256>::from_iter([
         U256::try_from_le_slice(
             Vec::<u8>::from_iter([
                 205, 105, 106, 166, 152, 194, 84, 202, 219, 225, 56, 160, 68, 10, 149, 101, 132,
@@ -8202,7 +8197,7 @@ fn test_basic_vector_vec_uint_256_2_random() {
     let recovered_value: Vector<U256, 2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xe765c4ca305f07d9e25e1c4c879528e9994b9fb5e4230bfda8c4b7805b1905c7");
     assert_eq!(root, expected_root);
@@ -8242,7 +8237,7 @@ fn test_basic_vector_vec_uint_256_2_random_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_256_2_zero() {
-    let mut value = Vector::<U256, 2>::try_from(Vec::<U256>::from_iter([
+    let value = Vector::<U256, 2>::try_from(Vec::<U256>::from_iter([
         U256::try_from_le_slice(
             Vec::<u8>::from_iter([
                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -8270,7 +8265,7 @@ fn test_basic_vector_vec_uint_256_2_zero() {
     let recovered_value: Vector<U256, 2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -8314,7 +8309,7 @@ fn test_basic_vector_vec_uint_256_2_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_256_31_max() {
-    let mut value = Vector::<U256, 31>::try_from(Vec::<U256>::from_iter([
+    let value = Vector::<U256, 31>::try_from(Vec::<U256>::from_iter([
         U256::try_from_le_slice(
             Vec::<u8>::from_iter([
                 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
@@ -8574,7 +8569,7 @@ fn test_basic_vector_vec_uint_256_31_max() {
     let recovered_value: Vector<U256, 31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x7399c0e47ac1d2d1e38e8ee039ef6242bd17bc41816dd9c49d0c7720687950df");
     assert_eq!(root, expected_root);
@@ -8628,7 +8623,7 @@ fn test_basic_vector_vec_uint_256_31_nil() {
 
 #[test]
 fn test_basic_vector_vec_uint_256_31_random() {
-    let mut value = Vector::<U256, 31>::try_from(Vec::<U256>::from_iter([
+    let value = Vector::<U256, 31>::try_from(Vec::<U256>::from_iter([
         U256::try_from_le_slice(
             Vec::<u8>::from_iter([
                 193, 221, 0, 27, 7, 14, 132, 79, 246, 169, 102, 206, 52, 7, 70, 134, 104, 201, 85,
@@ -8888,7 +8883,7 @@ fn test_basic_vector_vec_uint_256_31_random() {
     let recovered_value: Vector<U256, 31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xa1bd4eec44b1f37b07b53f29daf2a3569be0d6ebe727e18539071206950a6813");
     assert_eq!(root, expected_root);
@@ -8928,7 +8923,7 @@ fn test_basic_vector_vec_uint_256_31_random_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_256_31_zero() {
-    let mut value = Vector::<U256, 31>::try_from(Vec::<U256>::from_iter([
+    let value = Vector::<U256, 31>::try_from(Vec::<U256>::from_iter([
         U256::try_from_le_slice(
             Vec::<u8>::from_iter([
                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -9188,7 +9183,7 @@ fn test_basic_vector_vec_uint_256_31_zero() {
     let recovered_value: Vector<U256, 31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x9efde052aa15429fae05bad4d0b1d7c64da64d03d7a1854a588c2cb8430c0d30");
     assert_eq!(root, expected_root);
@@ -9232,7 +9227,7 @@ fn test_basic_vector_vec_uint_256_31_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_256_3_max() {
-    let mut value = Vector::<U256, 3>::try_from(Vec::<U256>::from_iter([
+    let value = Vector::<U256, 3>::try_from(Vec::<U256>::from_iter([
         U256::try_from_le_slice(
             Vec::<u8>::from_iter([
                 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
@@ -9268,7 +9263,7 @@ fn test_basic_vector_vec_uint_256_3_max() {
     let recovered_value: Vector<U256, 3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x4a6ba660d16b4dde152d00ba82cdde34827411f341c56b102e7962410924ad36");
     assert_eq!(root, expected_root);
@@ -9322,7 +9317,7 @@ fn test_basic_vector_vec_uint_256_3_nil() {
 
 #[test]
 fn test_basic_vector_vec_uint_256_3_random() {
-    let mut value = Vector::<U256, 3>::try_from(Vec::<U256>::from_iter([
+    let value = Vector::<U256, 3>::try_from(Vec::<U256>::from_iter([
         U256::try_from_le_slice(
             Vec::<u8>::from_iter([
                 180, 21, 110, 11, 140, 206, 247, 50, 116, 42, 151, 240, 95, 129, 184, 145, 10, 60,
@@ -9358,7 +9353,7 @@ fn test_basic_vector_vec_uint_256_3_random() {
     let recovered_value: Vector<U256, 3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0d0ad5da1149666a95382488e4164f5eaf34c9a5d4616dabaf74fc5c1cb5416c");
     assert_eq!(root, expected_root);
@@ -9398,7 +9393,7 @@ fn test_basic_vector_vec_uint_256_3_random_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_256_3_zero() {
-    let mut value = Vector::<U256, 3>::try_from(Vec::<U256>::from_iter([
+    let value = Vector::<U256, 3>::try_from(Vec::<U256>::from_iter([
         U256::try_from_le_slice(
             Vec::<u8>::from_iter([
                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -9434,7 +9429,7 @@ fn test_basic_vector_vec_uint_256_3_zero() {
     let recovered_value: Vector<U256, 3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xdb56114e00fdd4c1f85c892bf35ac9a89289aaecb1ebd0a96cde606a748b5d71");
     assert_eq!(root, expected_root);
@@ -9478,7 +9473,7 @@ fn test_basic_vector_vec_uint_256_3_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_256_4_max() {
-    let mut value = Vector::<U256, 4>::try_from(Vec::<U256>::from_iter([
+    let value = Vector::<U256, 4>::try_from(Vec::<U256>::from_iter([
         U256::try_from_le_slice(
             Vec::<u8>::from_iter([
                 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
@@ -9522,7 +9517,7 @@ fn test_basic_vector_vec_uint_256_4_max() {
     let recovered_value: Vector<U256, 4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x375d6c7b280a1e30f968db1d948da0f977bf9139b0d5516761ac874700208aba");
     assert_eq!(root, expected_root);
@@ -9576,7 +9571,7 @@ fn test_basic_vector_vec_uint_256_4_nil() {
 
 #[test]
 fn test_basic_vector_vec_uint_256_4_random() {
-    let mut value = Vector::<U256, 4>::try_from(Vec::<U256>::from_iter([
+    let value = Vector::<U256, 4>::try_from(Vec::<U256>::from_iter([
         U256::try_from_le_slice(
             Vec::<u8>::from_iter([
                 71, 106, 105, 163, 151, 75, 86, 137, 3, 140, 57, 168, 63, 49, 156, 118, 90, 171,
@@ -9620,7 +9615,7 @@ fn test_basic_vector_vec_uint_256_4_random() {
     let recovered_value: Vector<U256, 4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xfa6875722e5f598b45c4b742d1156f397f73e5aeb1a6bb33eed523bdba40693d");
     assert_eq!(root, expected_root);
@@ -9660,7 +9655,7 @@ fn test_basic_vector_vec_uint_256_4_random_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_256_4_zero() {
-    let mut value = Vector::<U256, 4>::try_from(Vec::<U256>::from_iter([
+    let value = Vector::<U256, 4>::try_from(Vec::<U256>::from_iter([
         U256::try_from_le_slice(
             Vec::<u8>::from_iter([
                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -9704,7 +9699,7 @@ fn test_basic_vector_vec_uint_256_4_zero() {
     let recovered_value: Vector<U256, 4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xdb56114e00fdd4c1f85c892bf35ac9a89289aaecb1ebd0a96cde606a748b5d71");
     assert_eq!(root, expected_root);
@@ -9748,7 +9743,7 @@ fn test_basic_vector_vec_uint_256_4_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_256_512_max() {
-    let mut value = Vector::<U256, 512>::try_from(Vec::<U256>::from_iter([
+    let value = Vector::<U256, 512>::try_from(Vec::<U256>::from_iter([
         U256::try_from_le_slice(
             Vec::<u8>::from_iter([
                 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
@@ -13856,7 +13851,7 @@ fn test_basic_vector_vec_uint_256_512_max() {
     let recovered_value: Vector<U256, 512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xa278cf32ca74f920b67a7b3d02447453d8883fecb4a7aa1ba4327079fa3d5162");
     assert_eq!(root, expected_root);
@@ -13910,7 +13905,7 @@ fn test_basic_vector_vec_uint_256_512_nil() {
 
 #[test]
 fn test_basic_vector_vec_uint_256_512_random() {
-    let mut value = Vector::<U256, 512>::try_from(Vec::<U256>::from_iter([
+    let value = Vector::<U256, 512>::try_from(Vec::<U256>::from_iter([
         U256::try_from_le_slice(
             Vec::<u8>::from_iter([
                 139, 35, 218, 181, 245, 36, 123, 0, 134, 153, 41, 134, 218, 150, 141, 38, 149, 194,
@@ -18018,7 +18013,7 @@ fn test_basic_vector_vec_uint_256_512_random() {
     let recovered_value: Vector<U256, 512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x88320d2bead34a47f2ef4e1e8e415b42bcb9955ad04e06ff309d49681c2628f2");
     assert_eq!(root, expected_root);
@@ -18058,7 +18053,7 @@ fn test_basic_vector_vec_uint_256_512_random_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_256_512_zero() {
-    let mut value = Vector::<U256, 512>::try_from(Vec::<U256>::from_iter([
+    let value = Vector::<U256, 512>::try_from(Vec::<U256>::from_iter([
         U256::try_from_le_slice(
             Vec::<u8>::from_iter([
                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -22166,7 +22161,7 @@ fn test_basic_vector_vec_uint_256_512_zero() {
     let recovered_value: Vector<U256, 512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x506d86582d252405b840018792cad2bf1259f1ef5aa5f887e13cb2f0094f51e1");
     assert_eq!(root, expected_root);
@@ -22206,7 +22201,7 @@ fn test_basic_vector_vec_uint_256_512_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_256_513_max() {
-    let mut value = Vector::<U256, 513>::try_from(Vec::<U256>::from_iter([
+    let value = Vector::<U256, 513>::try_from(Vec::<U256>::from_iter([
         U256::try_from_le_slice(
             Vec::<u8>::from_iter([
                 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
@@ -26322,7 +26317,7 @@ fn test_basic_vector_vec_uint_256_513_max() {
     let recovered_value: Vector<U256, 513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x8d90ae08c4b61479f6867707545ea8b26e91d9ef54e863a8daf7427f1e4d04c1");
     assert_eq!(root, expected_root);
@@ -26376,7 +26371,7 @@ fn test_basic_vector_vec_uint_256_513_nil() {
 
 #[test]
 fn test_basic_vector_vec_uint_256_513_random() {
-    let mut value = Vector::<U256, 513>::try_from(Vec::<U256>::from_iter([
+    let value = Vector::<U256, 513>::try_from(Vec::<U256>::from_iter([
         U256::try_from_le_slice(
             Vec::<u8>::from_iter([
                 178, 71, 197, 209, 59, 6, 21, 36, 228, 31, 161, 186, 233, 29, 46, 37, 73, 216, 72,
@@ -30492,7 +30487,7 @@ fn test_basic_vector_vec_uint_256_513_random() {
     let recovered_value: Vector<U256, 513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xcf114fb32b16706fc55188ad17f4dcced660baf4f31353048a5f51317134dc2b");
     assert_eq!(root, expected_root);
@@ -30532,7 +30527,7 @@ fn test_basic_vector_vec_uint_256_513_random_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_256_513_zero() {
-    let mut value = Vector::<U256, 513>::try_from(Vec::<U256>::from_iter([
+    let value = Vector::<U256, 513>::try_from(Vec::<U256>::from_iter([
         U256::try_from_le_slice(
             Vec::<u8>::from_iter([
                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -34648,7 +34643,7 @@ fn test_basic_vector_vec_uint_256_513_zero() {
     let recovered_value: Vector<U256, 513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xffff0ad7e659772f9534c195c815efc4014ef1e1daed4404c06385d11192e92b");
     assert_eq!(root, expected_root);
@@ -34688,7 +34683,7 @@ fn test_basic_vector_vec_uint_256_513_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_256_5_max() {
-    let mut value = Vector::<U256, 5>::try_from(Vec::<U256>::from_iter([
+    let value = Vector::<U256, 5>::try_from(Vec::<U256>::from_iter([
         U256::try_from_le_slice(
             Vec::<u8>::from_iter([
                 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
@@ -34740,7 +34735,7 @@ fn test_basic_vector_vec_uint_256_5_max() {
     let recovered_value: Vector<U256, 5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x8a70016e9e63b5927d8575c08b19132107772e149f3d1ba4e1b4306dce9b7aa5");
     assert_eq!(root, expected_root);
@@ -34794,7 +34789,7 @@ fn test_basic_vector_vec_uint_256_5_nil() {
 
 #[test]
 fn test_basic_vector_vec_uint_256_5_random() {
-    let mut value = Vector::<U256, 5>::try_from(Vec::<U256>::from_iter([
+    let value = Vector::<U256, 5>::try_from(Vec::<U256>::from_iter([
         U256::try_from_le_slice(
             Vec::<u8>::from_iter([
                 179, 22, 196, 129, 77, 158, 184, 168, 7, 100, 123, 93, 196, 11, 104, 117, 250, 160,
@@ -34846,7 +34841,7 @@ fn test_basic_vector_vec_uint_256_5_random() {
     let recovered_value: Vector<U256, 5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x2080573f384b29b3453b8cc44a967325a2e9ad22cb1b3f1d81554bb11479c2bc");
     assert_eq!(root, expected_root);
@@ -34886,7 +34881,7 @@ fn test_basic_vector_vec_uint_256_5_random_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_256_5_zero() {
-    let mut value = Vector::<U256, 5>::try_from(Vec::<U256>::from_iter([
+    let value = Vector::<U256, 5>::try_from(Vec::<U256>::from_iter([
         U256::try_from_le_slice(
             Vec::<u8>::from_iter([
                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -34938,7 +34933,7 @@ fn test_basic_vector_vec_uint_256_5_zero() {
     let recovered_value: Vector<U256, 5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xc78009fdf07fc56a11f122370658a353aaa542ed63e44c4bc15ff4cd105ab33c");
     assert_eq!(root, expected_root);
@@ -34982,7 +34977,7 @@ fn test_basic_vector_vec_uint_256_5_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_256_8_max() {
-    let mut value = Vector::<U256, 8>::try_from(Vec::<U256>::from_iter([
+    let value = Vector::<U256, 8>::try_from(Vec::<U256>::from_iter([
         U256::try_from_le_slice(
             Vec::<u8>::from_iter([
                 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
@@ -35058,7 +35053,7 @@ fn test_basic_vector_vec_uint_256_8_max() {
     let recovered_value: Vector<U256, 8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xbe1b7015ed50d7490a51f1b11dff804a4440775cc808b9cfd26157805c1f8e86");
     assert_eq!(root, expected_root);
@@ -35112,7 +35107,7 @@ fn test_basic_vector_vec_uint_256_8_nil() {
 
 #[test]
 fn test_basic_vector_vec_uint_256_8_random() {
-    let mut value = Vector::<U256, 8>::try_from(Vec::<U256>::from_iter([
+    let value = Vector::<U256, 8>::try_from(Vec::<U256>::from_iter([
         U256::try_from_le_slice(
             Vec::<u8>::from_iter([
                 101, 98, 195, 77, 141, 84, 10, 65, 199, 185, 225, 176, 137, 102, 31, 27, 37, 157,
@@ -35188,7 +35183,7 @@ fn test_basic_vector_vec_uint_256_8_random() {
     let recovered_value: Vector<U256, 8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf37250ebb8bfc70f992eb9c95107ea4def905c0062cda51a2688641a19645505");
     assert_eq!(root, expected_root);
@@ -35228,7 +35223,7 @@ fn test_basic_vector_vec_uint_256_8_random_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_256_8_zero() {
-    let mut value = Vector::<U256, 8>::try_from(Vec::<U256>::from_iter([
+    let value = Vector::<U256, 8>::try_from(Vec::<U256>::from_iter([
         U256::try_from_le_slice(
             Vec::<u8>::from_iter([
                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -35304,7 +35299,7 @@ fn test_basic_vector_vec_uint_256_8_zero() {
     let recovered_value: Vector<U256, 8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xc78009fdf07fc56a11f122370658a353aaa542ed63e44c4bc15ff4cd105ab33c");
     assert_eq!(root, expected_root);
@@ -35358,7 +35353,7 @@ fn test_basic_vector_vec_uint_32_0() {
 
 #[test]
 fn test_basic_vector_vec_uint_32_16_max() {
-    let mut value = Vector::<u32, 16>::try_from(Vec::<u32>::from_iter([
+    let value = Vector::<u32, 16>::try_from(Vec::<u32>::from_iter([
         4294967295, 4294967295, 4294967295, 4294967295, 4294967295, 4294967295, 4294967295,
         4294967295, 4294967295, 4294967295, 4294967295, 4294967295, 4294967295, 4294967295,
         4294967295, 4294967295,
@@ -35373,7 +35368,7 @@ fn test_basic_vector_vec_uint_32_16_max() {
     let recovered_value: Vector<u32, 16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x8667e718294e9e0df1d30600ba3eeb201f764aad2dad72748643e4a285e1d1f7");
     assert_eq!(root, expected_root);
@@ -35427,7 +35422,7 @@ fn test_basic_vector_vec_uint_32_16_nil() {
 
 #[test]
 fn test_basic_vector_vec_uint_32_16_random() {
-    let mut value = Vector::<u32, 16>::try_from(Vec::<u32>::from_iter([
+    let value = Vector::<u32, 16>::try_from(Vec::<u32>::from_iter([
         1381494992, 3456058494, 3316673465, 2895863808, 3039979229, 2658482247, 324065072,
         1118337861, 3690875953, 98201721, 1227056475, 2365715743, 1634445540, 616917765,
         1742195761, 2632010539,
@@ -35442,7 +35437,7 @@ fn test_basic_vector_vec_uint_32_16_random() {
     let recovered_value: Vector<u32, 16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x83aab501333050d1fbd420a889c52af0f2c274a1e4529a5c287b805ed477ccf6");
     assert_eq!(root, expected_root);
@@ -35482,7 +35477,7 @@ fn test_basic_vector_vec_uint_32_16_random_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_32_16_zero() {
-    let mut value = Vector::<u32, 16>::try_from(Vec::<u32>::from_iter([
+    let value = Vector::<u32, 16>::try_from(Vec::<u32>::from_iter([
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     ]))
     .unwrap();
@@ -35495,7 +35490,7 @@ fn test_basic_vector_vec_uint_32_16_zero() {
     let recovered_value: Vector<u32, 16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -35539,7 +35534,7 @@ fn test_basic_vector_vec_uint_32_16_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_32_1_max() {
-    let mut value = Vector::<u32, 1>::try_from(Vec::<u32>::from_iter([4294967295])).unwrap();
+    let value = Vector::<u32, 1>::try_from(Vec::<u32>::from_iter([4294967295])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/basic_vector/valid/vec_uint32_1_max/serialized.ssz_snappy",
@@ -35549,7 +35544,7 @@ fn test_basic_vector_vec_uint_32_1_max() {
     let recovered_value: Vector<u32, 1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xffffffff00000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -35603,7 +35598,7 @@ fn test_basic_vector_vec_uint_32_1_nil() {
 
 #[test]
 fn test_basic_vector_vec_uint_32_1_random() {
-    let mut value = Vector::<u32, 1>::try_from(Vec::<u32>::from_iter([1797257601])).unwrap();
+    let value = Vector::<u32, 1>::try_from(Vec::<u32>::from_iter([1797257601])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/basic_vector/valid/vec_uint32_1_random/serialized.ssz_snappy",
@@ -35613,7 +35608,7 @@ fn test_basic_vector_vec_uint_32_1_random() {
     let recovered_value: Vector<u32, 1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x81f91f6b00000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -35657,7 +35652,7 @@ fn test_basic_vector_vec_uint_32_1_random_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_32_1_zero() {
-    let mut value = Vector::<u32, 1>::try_from(Vec::<u32>::from_iter([0])).unwrap();
+    let value = Vector::<u32, 1>::try_from(Vec::<u32>::from_iter([0])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/basic_vector/valid/vec_uint32_1_zero/serialized.ssz_snappy",
@@ -35667,7 +35662,7 @@ fn test_basic_vector_vec_uint_32_1_zero() {
     let recovered_value: Vector<u32, 1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -35711,7 +35706,7 @@ fn test_basic_vector_vec_uint_32_1_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_32_2_max() {
-    let mut value =
+    let value =
         Vector::<u32, 2>::try_from(Vec::<u32>::from_iter([4294967295, 4294967295])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -35722,7 +35717,7 @@ fn test_basic_vector_vec_uint_32_2_max() {
     let recovered_value: Vector<u32, 2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xffffffffffffffff000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -35776,7 +35771,7 @@ fn test_basic_vector_vec_uint_32_2_nil() {
 
 #[test]
 fn test_basic_vector_vec_uint_32_2_random() {
-    let mut value =
+    let value =
         Vector::<u32, 2>::try_from(Vec::<u32>::from_iter([2286406229, 3289673013])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -35787,7 +35782,7 @@ fn test_basic_vector_vec_uint_32_2_random() {
     let recovered_value: Vector<u32, 2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x55ca4788356d14c4000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -35831,7 +35826,7 @@ fn test_basic_vector_vec_uint_32_2_random_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_32_2_zero() {
-    let mut value = Vector::<u32, 2>::try_from(Vec::<u32>::from_iter([0, 0])).unwrap();
+    let value = Vector::<u32, 2>::try_from(Vec::<u32>::from_iter([0, 0])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/basic_vector/valid/vec_uint32_2_zero/serialized.ssz_snappy",
@@ -35841,7 +35836,7 @@ fn test_basic_vector_vec_uint_32_2_zero() {
     let recovered_value: Vector<u32, 2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -35885,7 +35880,7 @@ fn test_basic_vector_vec_uint_32_2_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_32_31_max() {
-    let mut value = Vector::<u32, 31>::try_from(Vec::<u32>::from_iter([
+    let value = Vector::<u32, 31>::try_from(Vec::<u32>::from_iter([
         4294967295, 4294967295, 4294967295, 4294967295, 4294967295, 4294967295, 4294967295,
         4294967295, 4294967295, 4294967295, 4294967295, 4294967295, 4294967295, 4294967295,
         4294967295, 4294967295, 4294967295, 4294967295, 4294967295, 4294967295, 4294967295,
@@ -35902,7 +35897,7 @@ fn test_basic_vector_vec_uint_32_31_max() {
     let recovered_value: Vector<u32, 31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xe7492e2fb875c43b137514ed057ddfc23ddd1220431403c9a3395e2bbaf51407");
     assert_eq!(root, expected_root);
@@ -35956,7 +35951,7 @@ fn test_basic_vector_vec_uint_32_31_nil() {
 
 #[test]
 fn test_basic_vector_vec_uint_32_31_random() {
-    let mut value = Vector::<u32, 31>::try_from(Vec::<u32>::from_iter([
+    let value = Vector::<u32, 31>::try_from(Vec::<u32>::from_iter([
         508235682, 2308341395, 1525766118, 4136650562, 3621852454, 1567937308, 3269584467,
         1320546218, 2077416840, 739946730, 1282600407, 3203298029, 942979653, 497143087, 933745505,
         3794525861, 2714083317, 1289423485, 3524519556, 3497991789, 3711737680, 3061871525,
@@ -35973,7 +35968,7 @@ fn test_basic_vector_vec_uint_32_31_random() {
     let recovered_value: Vector<u32, 31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xefa45b70c8a45a482800655c239ed2e8d91d1325666fd1755da23b6fea1405ee");
     assert_eq!(root, expected_root);
@@ -36013,7 +36008,7 @@ fn test_basic_vector_vec_uint_32_31_random_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_32_31_zero() {
-    let mut value = Vector::<u32, 31>::try_from(Vec::<u32>::from_iter([
+    let value = Vector::<u32, 31>::try_from(Vec::<u32>::from_iter([
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     ]))
     .unwrap();
@@ -36026,7 +36021,7 @@ fn test_basic_vector_vec_uint_32_31_zero() {
     let recovered_value: Vector<u32, 31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xdb56114e00fdd4c1f85c892bf35ac9a89289aaecb1ebd0a96cde606a748b5d71");
     assert_eq!(root, expected_root);
@@ -36070,7 +36065,7 @@ fn test_basic_vector_vec_uint_32_31_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_32_3_max() {
-    let mut value =
+    let value =
         Vector::<u32, 3>::try_from(Vec::<u32>::from_iter([4294967295, 4294967295, 4294967295]))
             .unwrap();
     let encoding = serialize(&value);
@@ -36082,7 +36077,7 @@ fn test_basic_vector_vec_uint_32_3_max() {
     let recovered_value: Vector<u32, 3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xffffffffffffffffffffffff0000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -36136,7 +36131,7 @@ fn test_basic_vector_vec_uint_32_3_nil() {
 
 #[test]
 fn test_basic_vector_vec_uint_32_3_random() {
-    let mut value =
+    let value =
         Vector::<u32, 3>::try_from(Vec::<u32>::from_iter([414721764, 1396444802, 4099449558]))
             .unwrap();
     let encoding = serialize(&value);
@@ -36148,7 +36143,7 @@ fn test_basic_vector_vec_uint_32_3_random() {
     let recovered_value: Vector<u32, 3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xe426b818820e3c53d6a258f40000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -36192,7 +36187,7 @@ fn test_basic_vector_vec_uint_32_3_random_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_32_3_zero() {
-    let mut value = Vector::<u32, 3>::try_from(Vec::<u32>::from_iter([0, 0, 0])).unwrap();
+    let value = Vector::<u32, 3>::try_from(Vec::<u32>::from_iter([0, 0, 0])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/basic_vector/valid/vec_uint32_3_zero/serialized.ssz_snappy",
@@ -36202,7 +36197,7 @@ fn test_basic_vector_vec_uint_32_3_zero() {
     let recovered_value: Vector<u32, 3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -36246,7 +36241,7 @@ fn test_basic_vector_vec_uint_32_3_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_32_4_max() {
-    let mut value = Vector::<u32, 4>::try_from(Vec::<u32>::from_iter([
+    let value = Vector::<u32, 4>::try_from(Vec::<u32>::from_iter([
         4294967295, 4294967295, 4294967295, 4294967295,
     ]))
     .unwrap();
@@ -36259,7 +36254,7 @@ fn test_basic_vector_vec_uint_32_4_max() {
     let recovered_value: Vector<u32, 4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xffffffffffffffffffffffffffffffff00000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -36313,7 +36308,7 @@ fn test_basic_vector_vec_uint_32_4_nil() {
 
 #[test]
 fn test_basic_vector_vec_uint_32_4_random() {
-    let mut value = Vector::<u32, 4>::try_from(Vec::<u32>::from_iter([
+    let value = Vector::<u32, 4>::try_from(Vec::<u32>::from_iter([
         2599571881, 2754953818, 2448479820, 3973051506,
     ]))
     .unwrap();
@@ -36326,7 +36321,7 @@ fn test_basic_vector_vec_uint_32_4_random() {
     let recovered_value: Vector<u32, 4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xa951f29a5a4235a44cd6f09172f4cfec00000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -36370,7 +36365,7 @@ fn test_basic_vector_vec_uint_32_4_random_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_32_4_zero() {
-    let mut value = Vector::<u32, 4>::try_from(Vec::<u32>::from_iter([0, 0, 0, 0])).unwrap();
+    let value = Vector::<u32, 4>::try_from(Vec::<u32>::from_iter([0, 0, 0, 0])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/basic_vector/valid/vec_uint32_4_zero/serialized.ssz_snappy",
@@ -36380,7 +36375,7 @@ fn test_basic_vector_vec_uint_32_4_zero() {
     let recovered_value: Vector<u32, 4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -36424,7 +36419,7 @@ fn test_basic_vector_vec_uint_32_4_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_32_512_max() {
-    let mut value = Vector::<u32, 512>::try_from(Vec::<u32>::from_iter([
+    let value = Vector::<u32, 512>::try_from(Vec::<u32>::from_iter([
         4294967295, 4294967295, 4294967295, 4294967295, 4294967295, 4294967295, 4294967295,
         4294967295, 4294967295, 4294967295, 4294967295, 4294967295, 4294967295, 4294967295,
         4294967295, 4294967295, 4294967295, 4294967295, 4294967295, 4294967295, 4294967295,
@@ -36510,7 +36505,7 @@ fn test_basic_vector_vec_uint_32_512_max() {
     let recovered_value: Vector<u32, 512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x7c09b1cdfe9a7e172dfe2ca8715becf5132c036abbfdfb500daa9c51f365074d");
     assert_eq!(root, expected_root);
@@ -36564,7 +36559,7 @@ fn test_basic_vector_vec_uint_32_512_nil() {
 
 #[test]
 fn test_basic_vector_vec_uint_32_512_random() {
-    let mut value = Vector::<u32, 512>::try_from(Vec::<u32>::from_iter([
+    let value = Vector::<u32, 512>::try_from(Vec::<u32>::from_iter([
         3535294352, 2244578171, 32943704, 3015817426, 2456157102, 219351158, 2006999311,
         1996972550, 2838712831, 1656769757, 3318502982, 4213769932, 2050078503, 4292367497,
         4290313471, 1262779699, 4083724714, 1323361645, 974092343, 710698434, 2984936844,
@@ -36648,7 +36643,7 @@ fn test_basic_vector_vec_uint_32_512_random() {
     let recovered_value: Vector<u32, 512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x29520e549f20e52e3cd8ef74509a65c936a54c25207355c6c7d8b93b50c16b79");
     assert_eq!(root, expected_root);
@@ -36688,7 +36683,7 @@ fn test_basic_vector_vec_uint_32_512_random_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_32_512_zero() {
-    let mut value = Vector::<u32, 512>::try_from(Vec::<u32>::from_iter([
+    let value = Vector::<u32, 512>::try_from(Vec::<u32>::from_iter([
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -36718,7 +36713,7 @@ fn test_basic_vector_vec_uint_32_512_zero() {
     let recovered_value: Vector<u32, 512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xd88ddfeed400a8755596b21942c1497e114c302e6118290f91e6772976041fa1");
     assert_eq!(root, expected_root);
@@ -36762,7 +36757,7 @@ fn test_basic_vector_vec_uint_32_512_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_32_513_max() {
-    let mut value = Vector::<u32, 513>::try_from(Vec::<u32>::from_iter([
+    let value = Vector::<u32, 513>::try_from(Vec::<u32>::from_iter([
         4294967295, 4294967295, 4294967295, 4294967295, 4294967295, 4294967295, 4294967295,
         4294967295, 4294967295, 4294967295, 4294967295, 4294967295, 4294967295, 4294967295,
         4294967295, 4294967295, 4294967295, 4294967295, 4294967295, 4294967295, 4294967295,
@@ -36848,7 +36843,7 @@ fn test_basic_vector_vec_uint_32_513_max() {
     let recovered_value: Vector<u32, 513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xe243d140ab8d341e3cad517d2ba8cd3b8ef7df2ff6f6962f0aeaf20e366fe7e3");
     assert_eq!(root, expected_root);
@@ -36902,7 +36897,7 @@ fn test_basic_vector_vec_uint_32_513_nil() {
 
 #[test]
 fn test_basic_vector_vec_uint_32_513_random() {
-    let mut value = Vector::<u32, 513>::try_from(Vec::<u32>::from_iter([
+    let value = Vector::<u32, 513>::try_from(Vec::<u32>::from_iter([
         1506286316, 3340455671, 2249197219, 1137228810, 3708188369, 1032790960, 2037375995,
         2165993127, 4279139643, 2878934835, 2234060784, 3341241397, 2832291162, 1862974295,
         2889755957, 716023347, 1781425995, 2766618165, 430694095, 1734393401, 3038286926,
@@ -36987,7 +36982,7 @@ fn test_basic_vector_vec_uint_32_513_random() {
     let recovered_value: Vector<u32, 513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x73d6601e80c118fe2d467dcc72a40e9a121608b87b5d1333a6a95fcbc93af038");
     assert_eq!(root, expected_root);
@@ -37027,7 +37022,7 @@ fn test_basic_vector_vec_uint_32_513_random_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_32_513_zero() {
-    let mut value = Vector::<u32, 513>::try_from(Vec::<u32>::from_iter([
+    let value = Vector::<u32, 513>::try_from(Vec::<u32>::from_iter([
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -37057,7 +37052,7 @@ fn test_basic_vector_vec_uint_32_513_zero() {
     let recovered_value: Vector<u32, 513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x87eb0ddba57e35f6d286673802a4af5975e22506c7cf4c64bb6be5ee11527f2c");
     assert_eq!(root, expected_root);
@@ -37101,7 +37096,7 @@ fn test_basic_vector_vec_uint_32_513_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_32_5_max() {
-    let mut value = Vector::<u32, 5>::try_from(Vec::<u32>::from_iter([
+    let value = Vector::<u32, 5>::try_from(Vec::<u32>::from_iter([
         4294967295, 4294967295, 4294967295, 4294967295, 4294967295,
     ]))
     .unwrap();
@@ -37114,7 +37109,7 @@ fn test_basic_vector_vec_uint_32_5_max() {
     let recovered_value: Vector<u32, 5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xffffffffffffffffffffffffffffffffffffffff000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -37168,7 +37163,7 @@ fn test_basic_vector_vec_uint_32_5_nil() {
 
 #[test]
 fn test_basic_vector_vec_uint_32_5_random() {
-    let mut value = Vector::<u32, 5>::try_from(Vec::<u32>::from_iter([
+    let value = Vector::<u32, 5>::try_from(Vec::<u32>::from_iter([
         1051503312, 1875702585, 3338068896, 1062162289, 44280150,
     ]))
     .unwrap();
@@ -37181,7 +37176,7 @@ fn test_basic_vector_vec_uint_32_5_random() {
     let recovered_value: Vector<u32, 5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xd0aaac3e39f3cc6fa0e3f6c6714f4f3f56a9a302000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -37225,7 +37220,7 @@ fn test_basic_vector_vec_uint_32_5_random_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_32_5_zero() {
-    let mut value = Vector::<u32, 5>::try_from(Vec::<u32>::from_iter([0, 0, 0, 0, 0])).unwrap();
+    let value = Vector::<u32, 5>::try_from(Vec::<u32>::from_iter([0, 0, 0, 0, 0])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/basic_vector/valid/vec_uint32_5_zero/serialized.ssz_snappy",
@@ -37235,7 +37230,7 @@ fn test_basic_vector_vec_uint_32_5_zero() {
     let recovered_value: Vector<u32, 5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -37279,7 +37274,7 @@ fn test_basic_vector_vec_uint_32_5_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_32_8_max() {
-    let mut value = Vector::<u32, 8>::try_from(Vec::<u32>::from_iter([
+    let value = Vector::<u32, 8>::try_from(Vec::<u32>::from_iter([
         4294967295, 4294967295, 4294967295, 4294967295, 4294967295, 4294967295, 4294967295,
         4294967295,
     ]))
@@ -37293,7 +37288,7 @@ fn test_basic_vector_vec_uint_32_8_max() {
     let recovered_value: Vector<u32, 8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
     assert_eq!(root, expected_root);
@@ -37347,7 +37342,7 @@ fn test_basic_vector_vec_uint_32_8_nil() {
 
 #[test]
 fn test_basic_vector_vec_uint_32_8_random() {
-    let mut value = Vector::<u32, 8>::try_from(Vec::<u32>::from_iter([
+    let value = Vector::<u32, 8>::try_from(Vec::<u32>::from_iter([
         2255247108, 883929842, 2722841916, 3289001244, 3428769191, 4039771928, 1073577161,
         1629830620,
     ]))
@@ -37361,7 +37356,7 @@ fn test_basic_vector_vec_uint_32_8_random() {
     let recovered_value: Vector<u32, 8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x04576c86f2b2af343c454ba21c2d0ac4a7dd5ecc1807caf0c97cfd3fdc3d2561");
     assert_eq!(root, expected_root);
@@ -37405,7 +37400,7 @@ fn test_basic_vector_vec_uint_32_8_random_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_32_8_zero() {
-    let mut value =
+    let value =
         Vector::<u32, 8>::try_from(Vec::<u32>::from_iter([0, 0, 0, 0, 0, 0, 0, 0])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -37416,7 +37411,7 @@ fn test_basic_vector_vec_uint_32_8_zero() {
     let recovered_value: Vector<u32, 8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -37470,7 +37465,7 @@ fn test_basic_vector_vec_uint_64_0() {
 
 #[test]
 fn test_basic_vector_vec_uint_64_16_max() {
-    let mut value = Vector::<u64, 16>::try_from(Vec::<u64>::from_iter([
+    let value = Vector::<u64, 16>::try_from(Vec::<u64>::from_iter([
         18446744073709551615,
         18446744073709551615,
         18446744073709551615,
@@ -37498,7 +37493,7 @@ fn test_basic_vector_vec_uint_64_16_max() {
     let recovered_value: Vector<u64, 16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x375d6c7b280a1e30f968db1d948da0f977bf9139b0d5516761ac874700208aba");
     assert_eq!(root, expected_root);
@@ -37552,7 +37547,7 @@ fn test_basic_vector_vec_uint_64_16_nil() {
 
 #[test]
 fn test_basic_vector_vec_uint_64_16_random() {
-    let mut value = Vector::<u64, 16>::try_from(Vec::<u64>::from_iter([
+    let value = Vector::<u64, 16>::try_from(Vec::<u64>::from_iter([
         14973315493487554254,
         14609512114016110986,
         10032323568597029119,
@@ -37580,7 +37575,7 @@ fn test_basic_vector_vec_uint_64_16_random() {
     let recovered_value: Vector<u64, 16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x18efd70dfb660ebe73c72c6f8d0258f97495b3bf86a98741e3c9bfb2aeab5d28");
     assert_eq!(root, expected_root);
@@ -37620,7 +37615,7 @@ fn test_basic_vector_vec_uint_64_16_random_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_64_16_zero() {
-    let mut value = Vector::<u64, 16>::try_from(Vec::<u64>::from_iter([
+    let value = Vector::<u64, 16>::try_from(Vec::<u64>::from_iter([
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     ]))
     .unwrap();
@@ -37633,7 +37628,7 @@ fn test_basic_vector_vec_uint_64_16_zero() {
     let recovered_value: Vector<u64, 16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xdb56114e00fdd4c1f85c892bf35ac9a89289aaecb1ebd0a96cde606a748b5d71");
     assert_eq!(root, expected_root);
@@ -37677,8 +37672,7 @@ fn test_basic_vector_vec_uint_64_16_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_64_1_max() {
-    let mut value =
-        Vector::<u64, 1>::try_from(Vec::<u64>::from_iter([18446744073709551615])).unwrap();
+    let value = Vector::<u64, 1>::try_from(Vec::<u64>::from_iter([18446744073709551615])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/basic_vector/valid/vec_uint64_1_max/serialized.ssz_snappy",
@@ -37688,7 +37682,7 @@ fn test_basic_vector_vec_uint_64_1_max() {
     let recovered_value: Vector<u64, 1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xffffffffffffffff000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -37742,8 +37736,7 @@ fn test_basic_vector_vec_uint_64_1_nil() {
 
 #[test]
 fn test_basic_vector_vec_uint_64_1_random() {
-    let mut value =
-        Vector::<u64, 1>::try_from(Vec::<u64>::from_iter([8914067055681793591])).unwrap();
+    let value = Vector::<u64, 1>::try_from(Vec::<u64>::from_iter([8914067055681793591])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/basic_vector/valid/vec_uint64_1_random/serialized.ssz_snappy",
@@ -37753,7 +37746,7 @@ fn test_basic_vector_vec_uint_64_1_random() {
     let recovered_value: Vector<u64, 1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x37eeec25c220b57b000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -37797,7 +37790,7 @@ fn test_basic_vector_vec_uint_64_1_random_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_64_1_zero() {
-    let mut value = Vector::<u64, 1>::try_from(Vec::<u64>::from_iter([0])).unwrap();
+    let value = Vector::<u64, 1>::try_from(Vec::<u64>::from_iter([0])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/basic_vector/valid/vec_uint64_1_zero/serialized.ssz_snappy",
@@ -37807,7 +37800,7 @@ fn test_basic_vector_vec_uint_64_1_zero() {
     let recovered_value: Vector<u64, 1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -37851,7 +37844,7 @@ fn test_basic_vector_vec_uint_64_1_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_64_2_max() {
-    let mut value = Vector::<u64, 2>::try_from(Vec::<u64>::from_iter([
+    let value = Vector::<u64, 2>::try_from(Vec::<u64>::from_iter([
         18446744073709551615,
         18446744073709551615,
     ]))
@@ -37865,7 +37858,7 @@ fn test_basic_vector_vec_uint_64_2_max() {
     let recovered_value: Vector<u64, 2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xffffffffffffffffffffffffffffffff00000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -37919,7 +37912,7 @@ fn test_basic_vector_vec_uint_64_2_nil() {
 
 #[test]
 fn test_basic_vector_vec_uint_64_2_random() {
-    let mut value = Vector::<u64, 2>::try_from(Vec::<u64>::from_iter([
+    let value = Vector::<u64, 2>::try_from(Vec::<u64>::from_iter([
         16527226978582771838,
         7558561043290308816,
     ]))
@@ -37933,7 +37926,7 @@ fn test_basic_vector_vec_uint_64_2_random() {
     let recovered_value: Vector<u64, 2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x7eb8ad3c5f815ce5d0c06cce3867e56800000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -37977,7 +37970,7 @@ fn test_basic_vector_vec_uint_64_2_random_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_64_2_zero() {
-    let mut value = Vector::<u64, 2>::try_from(Vec::<u64>::from_iter([0, 0])).unwrap();
+    let value = Vector::<u64, 2>::try_from(Vec::<u64>::from_iter([0, 0])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/basic_vector/valid/vec_uint64_2_zero/serialized.ssz_snappy",
@@ -37987,7 +37980,7 @@ fn test_basic_vector_vec_uint_64_2_zero() {
     let recovered_value: Vector<u64, 2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -38031,7 +38024,7 @@ fn test_basic_vector_vec_uint_64_2_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_64_31_max() {
-    let mut value = Vector::<u64, 31>::try_from(Vec::<u64>::from_iter([
+    let value = Vector::<u64, 31>::try_from(Vec::<u64>::from_iter([
         18446744073709551615,
         18446744073709551615,
         18446744073709551615,
@@ -38074,7 +38067,7 @@ fn test_basic_vector_vec_uint_64_31_max() {
     let recovered_value: Vector<u64, 31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x6323465d736a7126b4e2a25da8d76670d49d6bb0cdf9ffc77d0b007a9e86d77c");
     assert_eq!(root, expected_root);
@@ -38128,7 +38121,7 @@ fn test_basic_vector_vec_uint_64_31_nil() {
 
 #[test]
 fn test_basic_vector_vec_uint_64_31_random() {
-    let mut value = Vector::<u64, 31>::try_from(Vec::<u64>::from_iter([
+    let value = Vector::<u64, 31>::try_from(Vec::<u64>::from_iter([
         3052724393868548387,
         3810693530679841654,
         12585541796688525245,
@@ -38171,7 +38164,7 @@ fn test_basic_vector_vec_uint_64_31_random() {
     let recovered_value: Vector<u64, 31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x692da28053f3e2d585e5359989519e2af9044140b7f50d0db8e36b89e5ddd6f3");
     assert_eq!(root, expected_root);
@@ -38211,7 +38204,7 @@ fn test_basic_vector_vec_uint_64_31_random_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_64_31_zero() {
-    let mut value = Vector::<u64, 31>::try_from(Vec::<u64>::from_iter([
+    let value = Vector::<u64, 31>::try_from(Vec::<u64>::from_iter([
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     ]))
     .unwrap();
@@ -38224,7 +38217,7 @@ fn test_basic_vector_vec_uint_64_31_zero() {
     let recovered_value: Vector<u64, 31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xc78009fdf07fc56a11f122370658a353aaa542ed63e44c4bc15ff4cd105ab33c");
     assert_eq!(root, expected_root);
@@ -38268,7 +38261,7 @@ fn test_basic_vector_vec_uint_64_31_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_64_3_max() {
-    let mut value = Vector::<u64, 3>::try_from(Vec::<u64>::from_iter([
+    let value = Vector::<u64, 3>::try_from(Vec::<u64>::from_iter([
         18446744073709551615,
         18446744073709551615,
         18446744073709551615,
@@ -38283,7 +38276,7 @@ fn test_basic_vector_vec_uint_64_3_max() {
     let recovered_value: Vector<u64, 3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xffffffffffffffffffffffffffffffffffffffffffffffff0000000000000000");
     assert_eq!(root, expected_root);
@@ -38337,7 +38330,7 @@ fn test_basic_vector_vec_uint_64_3_nil() {
 
 #[test]
 fn test_basic_vector_vec_uint_64_3_random() {
-    let mut value = Vector::<u64, 3>::try_from(Vec::<u64>::from_iter([
+    let value = Vector::<u64, 3>::try_from(Vec::<u64>::from_iter([
         6167802979638570618,
         1670982671822494120,
         2649190588485934153,
@@ -38352,7 +38345,7 @@ fn test_basic_vector_vec_uint_64_3_random() {
     let recovered_value: Vector<u64, 3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x7aeef3ad21709855a819d003e3853017491c03e1cdd0c3240000000000000000");
     assert_eq!(root, expected_root);
@@ -38396,7 +38389,7 @@ fn test_basic_vector_vec_uint_64_3_random_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_64_3_zero() {
-    let mut value = Vector::<u64, 3>::try_from(Vec::<u64>::from_iter([0, 0, 0])).unwrap();
+    let value = Vector::<u64, 3>::try_from(Vec::<u64>::from_iter([0, 0, 0])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/basic_vector/valid/vec_uint64_3_zero/serialized.ssz_snappy",
@@ -38406,7 +38399,7 @@ fn test_basic_vector_vec_uint_64_3_zero() {
     let recovered_value: Vector<u64, 3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -38450,7 +38443,7 @@ fn test_basic_vector_vec_uint_64_3_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_64_4_max() {
-    let mut value = Vector::<u64, 4>::try_from(Vec::<u64>::from_iter([
+    let value = Vector::<u64, 4>::try_from(Vec::<u64>::from_iter([
         18446744073709551615,
         18446744073709551615,
         18446744073709551615,
@@ -38466,7 +38459,7 @@ fn test_basic_vector_vec_uint_64_4_max() {
     let recovered_value: Vector<u64, 4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
     assert_eq!(root, expected_root);
@@ -38520,7 +38513,7 @@ fn test_basic_vector_vec_uint_64_4_nil() {
 
 #[test]
 fn test_basic_vector_vec_uint_64_4_random() {
-    let mut value = Vector::<u64, 4>::try_from(Vec::<u64>::from_iter([
+    let value = Vector::<u64, 4>::try_from(Vec::<u64>::from_iter([
         7900660817174063737,
         6533979385570669156,
         4271747397033668748,
@@ -38536,7 +38529,7 @@ fn test_basic_vector_vec_uint_64_4_random() {
     let recovered_value: Vector<u64, 4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x79ea815a27c9a46d6432aaf6a15bad5a8c3064fa9f4b483bda4bf4888173cf30");
     assert_eq!(root, expected_root);
@@ -38580,7 +38573,7 @@ fn test_basic_vector_vec_uint_64_4_random_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_64_4_zero() {
-    let mut value = Vector::<u64, 4>::try_from(Vec::<u64>::from_iter([0, 0, 0, 0])).unwrap();
+    let value = Vector::<u64, 4>::try_from(Vec::<u64>::from_iter([0, 0, 0, 0])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/basic_vector/valid/vec_uint64_4_zero/serialized.ssz_snappy",
@@ -38590,7 +38583,7 @@ fn test_basic_vector_vec_uint_64_4_zero() {
     let recovered_value: Vector<u64, 4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -38634,7 +38627,7 @@ fn test_basic_vector_vec_uint_64_4_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_64_512_max() {
-    let mut value = Vector::<u64, 512>::try_from(Vec::<u64>::from_iter([
+    let value = Vector::<u64, 512>::try_from(Vec::<u64>::from_iter([
         18446744073709551615,
         18446744073709551615,
         18446744073709551615,
@@ -39158,7 +39151,7 @@ fn test_basic_vector_vec_uint_64_512_max() {
     let recovered_value: Vector<u64, 512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x8f711e9197bcd96314b8d20425eac7dce4aee7c9a0579e901d636d3256db3672");
     assert_eq!(root, expected_root);
@@ -39212,7 +39205,7 @@ fn test_basic_vector_vec_uint_64_512_nil() {
 
 #[test]
 fn test_basic_vector_vec_uint_64_512_random() {
-    let mut value = Vector::<u64, 512>::try_from(Vec::<u64>::from_iter([
+    let value = Vector::<u64, 512>::try_from(Vec::<u64>::from_iter([
         17241722399186003656,
         4508348299491693172,
         6390266777275510888,
@@ -39736,7 +39729,7 @@ fn test_basic_vector_vec_uint_64_512_random() {
     let recovered_value: Vector<u64, 512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0dac791ef3e531baa9195787060367a1ea72df21153ceff38d53d67bdbf14cdb");
     assert_eq!(root, expected_root);
@@ -39776,7 +39769,7 @@ fn test_basic_vector_vec_uint_64_512_random_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_64_512_zero() {
-    let mut value = Vector::<u64, 512>::try_from(Vec::<u64>::from_iter([
+    let value = Vector::<u64, 512>::try_from(Vec::<u64>::from_iter([
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -39806,7 +39799,7 @@ fn test_basic_vector_vec_uint_64_512_zero() {
     let recovered_value: Vector<u64, 512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x87eb0ddba57e35f6d286673802a4af5975e22506c7cf4c64bb6be5ee11527f2c");
     assert_eq!(root, expected_root);
@@ -39850,7 +39843,7 @@ fn test_basic_vector_vec_uint_64_512_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_64_513_max() {
-    let mut value = Vector::<u64, 513>::try_from(Vec::<u64>::from_iter([
+    let value = Vector::<u64, 513>::try_from(Vec::<u64>::from_iter([
         18446744073709551615,
         18446744073709551615,
         18446744073709551615,
@@ -40375,7 +40368,7 @@ fn test_basic_vector_vec_uint_64_513_max() {
     let recovered_value: Vector<u64, 513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x76e07c25312b02171801bc5bfa77a4c4f65ca1a93464d9812362009307ecfb55");
     assert_eq!(root, expected_root);
@@ -40429,7 +40422,7 @@ fn test_basic_vector_vec_uint_64_513_nil() {
 
 #[test]
 fn test_basic_vector_vec_uint_64_513_random() {
-    let mut value = Vector::<u64, 513>::try_from(Vec::<u64>::from_iter([
+    let value = Vector::<u64, 513>::try_from(Vec::<u64>::from_iter([
         977103724348450572,
         16638432304304789571,
         12981575418293692183,
@@ -40954,7 +40947,7 @@ fn test_basic_vector_vec_uint_64_513_random() {
     let recovered_value: Vector<u64, 513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf6fe5bb836cca4115fcca592f3ca646c0d56b4ab316eb8f469c372846ec6d7f6");
     assert_eq!(root, expected_root);
@@ -40994,7 +40987,7 @@ fn test_basic_vector_vec_uint_64_513_random_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_64_513_zero() {
-    let mut value = Vector::<u64, 513>::try_from(Vec::<u64>::from_iter([
+    let value = Vector::<u64, 513>::try_from(Vec::<u64>::from_iter([
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -41024,7 +41017,7 @@ fn test_basic_vector_vec_uint_64_513_zero() {
     let recovered_value: Vector<u64, 513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x26846476fd5fc54a5d43385167c95144f2643f533cc85bb9d16b782f8d7db193");
     assert_eq!(root, expected_root);
@@ -41068,7 +41061,7 @@ fn test_basic_vector_vec_uint_64_513_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_64_5_max() {
-    let mut value = Vector::<u64, 5>::try_from(Vec::<u64>::from_iter([
+    let value = Vector::<u64, 5>::try_from(Vec::<u64>::from_iter([
         18446744073709551615,
         18446744073709551615,
         18446744073709551615,
@@ -41085,7 +41078,7 @@ fn test_basic_vector_vec_uint_64_5_max() {
     let recovered_value: Vector<u64, 5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf0b46c4ab8cd5720de9457addeff0a7267e475c09fd5abb6661e32faf9dd30cd");
     assert_eq!(root, expected_root);
@@ -41139,7 +41132,7 @@ fn test_basic_vector_vec_uint_64_5_nil() {
 
 #[test]
 fn test_basic_vector_vec_uint_64_5_random() {
-    let mut value = Vector::<u64, 5>::try_from(Vec::<u64>::from_iter([
+    let value = Vector::<u64, 5>::try_from(Vec::<u64>::from_iter([
         5828194763697002133,
         3153164540286514337,
         17780602567657386724,
@@ -41156,7 +41149,7 @@ fn test_basic_vector_vec_uint_64_5_random() {
     let recovered_value: Vector<u64, 5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x11f1f940a8342239bd6a9f7eb4f08eff81e1d4467df7399a6d8729c59aabb984");
     assert_eq!(root, expected_root);
@@ -41200,7 +41193,7 @@ fn test_basic_vector_vec_uint_64_5_random_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_64_5_zero() {
-    let mut value = Vector::<u64, 5>::try_from(Vec::<u64>::from_iter([0, 0, 0, 0, 0])).unwrap();
+    let value = Vector::<u64, 5>::try_from(Vec::<u64>::from_iter([0, 0, 0, 0, 0])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/basic_vector/valid/vec_uint64_5_zero/serialized.ssz_snappy",
@@ -41210,7 +41203,7 @@ fn test_basic_vector_vec_uint_64_5_zero() {
     let recovered_value: Vector<u64, 5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -41254,7 +41247,7 @@ fn test_basic_vector_vec_uint_64_5_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_64_8_max() {
-    let mut value = Vector::<u64, 8>::try_from(Vec::<u64>::from_iter([
+    let value = Vector::<u64, 8>::try_from(Vec::<u64>::from_iter([
         18446744073709551615,
         18446744073709551615,
         18446744073709551615,
@@ -41274,7 +41267,7 @@ fn test_basic_vector_vec_uint_64_8_max() {
     let recovered_value: Vector<u64, 8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x8667e718294e9e0df1d30600ba3eeb201f764aad2dad72748643e4a285e1d1f7");
     assert_eq!(root, expected_root);
@@ -41328,7 +41321,7 @@ fn test_basic_vector_vec_uint_64_8_nil() {
 
 #[test]
 fn test_basic_vector_vec_uint_64_8_random() {
-    let mut value = Vector::<u64, 8>::try_from(Vec::<u64>::from_iter([
+    let value = Vector::<u64, 8>::try_from(Vec::<u64>::from_iter([
         598083651574187315,
         16261093746939895763,
         11288686854153899408,
@@ -41348,7 +41341,7 @@ fn test_basic_vector_vec_uint_64_8_random() {
     let recovered_value: Vector<u64, 8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xd5a3754afc2badf65538d7358ba6199e5433893701dafc2f775e6e3b49cf13ca");
     assert_eq!(root, expected_root);
@@ -41392,7 +41385,7 @@ fn test_basic_vector_vec_uint_64_8_random_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_64_8_zero() {
-    let mut value =
+    let value =
         Vector::<u64, 8>::try_from(Vec::<u64>::from_iter([0, 0, 0, 0, 0, 0, 0, 0])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -41403,7 +41396,7 @@ fn test_basic_vector_vec_uint_64_8_zero() {
     let recovered_value: Vector<u64, 8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -41457,7 +41450,7 @@ fn test_basic_vector_vec_uint_8_0() {
 
 #[test]
 fn test_basic_vector_vec_uint_8_16_max() {
-    let mut value = Vector::<u8, 16>::try_from(Vec::<u8>::from_iter([
+    let value = Vector::<u8, 16>::try_from(Vec::<u8>::from_iter([
         255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
     ]))
     .unwrap();
@@ -41470,7 +41463,7 @@ fn test_basic_vector_vec_uint_8_16_max() {
     let recovered_value: Vector<u8, 16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xffffffffffffffffffffffffffffffff00000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -41524,7 +41517,7 @@ fn test_basic_vector_vec_uint_8_16_nil() {
 
 #[test]
 fn test_basic_vector_vec_uint_8_16_random() {
-    let mut value = Vector::<u8, 16>::try_from(Vec::<u8>::from_iter([
+    let value = Vector::<u8, 16>::try_from(Vec::<u8>::from_iter([
         238, 35, 45, 23, 138, 32, 154, 246, 181, 136, 127, 102, 232, 9, 36, 2,
     ]))
     .unwrap();
@@ -41537,7 +41530,7 @@ fn test_basic_vector_vec_uint_8_16_random() {
     let recovered_value: Vector<u8, 16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xee232d178a209af6b5887f66e809240200000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -41581,7 +41574,7 @@ fn test_basic_vector_vec_uint_8_16_random_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_8_16_zero() {
-    let mut value = Vector::<u8, 16>::try_from(Vec::<u8>::from_iter([
+    let value = Vector::<u8, 16>::try_from(Vec::<u8>::from_iter([
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     ]))
     .unwrap();
@@ -41594,7 +41587,7 @@ fn test_basic_vector_vec_uint_8_16_zero() {
     let recovered_value: Vector<u8, 16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -41638,7 +41631,7 @@ fn test_basic_vector_vec_uint_8_16_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_8_1_max() {
-    let mut value = Vector::<u8, 1>::try_from(Vec::<u8>::from_iter([255])).unwrap();
+    let value = Vector::<u8, 1>::try_from(Vec::<u8>::from_iter([255])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/basic_vector/valid/vec_uint8_1_max/serialized.ssz_snappy",
@@ -41648,7 +41641,7 @@ fn test_basic_vector_vec_uint_8_1_max() {
     let recovered_value: Vector<u8, 1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xff00000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -41702,7 +41695,7 @@ fn test_basic_vector_vec_uint_8_1_nil() {
 
 #[test]
 fn test_basic_vector_vec_uint_8_1_random() {
-    let mut value = Vector::<u8, 1>::try_from(Vec::<u8>::from_iter([225])).unwrap();
+    let value = Vector::<u8, 1>::try_from(Vec::<u8>::from_iter([225])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/basic_vector/valid/vec_uint8_1_random/serialized.ssz_snappy",
@@ -41712,7 +41705,7 @@ fn test_basic_vector_vec_uint_8_1_random() {
     let recovered_value: Vector<u8, 1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xe100000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -41756,7 +41749,7 @@ fn test_basic_vector_vec_uint_8_1_random_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_8_1_zero() {
-    let mut value = Vector::<u8, 1>::try_from(Vec::<u8>::from_iter([0])).unwrap();
+    let value = Vector::<u8, 1>::try_from(Vec::<u8>::from_iter([0])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/basic_vector/valid/vec_uint8_1_zero/serialized.ssz_snappy",
@@ -41766,7 +41759,7 @@ fn test_basic_vector_vec_uint_8_1_zero() {
     let recovered_value: Vector<u8, 1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -41810,7 +41803,7 @@ fn test_basic_vector_vec_uint_8_1_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_8_2_max() {
-    let mut value = Vector::<u8, 2>::try_from(Vec::<u8>::from_iter([255, 255])).unwrap();
+    let value = Vector::<u8, 2>::try_from(Vec::<u8>::from_iter([255, 255])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/basic_vector/valid/vec_uint8_2_max/serialized.ssz_snappy",
@@ -41820,7 +41813,7 @@ fn test_basic_vector_vec_uint_8_2_max() {
     let recovered_value: Vector<u8, 2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xffff000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -41874,7 +41867,7 @@ fn test_basic_vector_vec_uint_8_2_nil() {
 
 #[test]
 fn test_basic_vector_vec_uint_8_2_random() {
-    let mut value = Vector::<u8, 2>::try_from(Vec::<u8>::from_iter([59, 3])).unwrap();
+    let value = Vector::<u8, 2>::try_from(Vec::<u8>::from_iter([59, 3])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/basic_vector/valid/vec_uint8_2_random/serialized.ssz_snappy",
@@ -41884,7 +41877,7 @@ fn test_basic_vector_vec_uint_8_2_random() {
     let recovered_value: Vector<u8, 2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x3b03000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -41928,7 +41921,7 @@ fn test_basic_vector_vec_uint_8_2_random_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_8_2_zero() {
-    let mut value = Vector::<u8, 2>::try_from(Vec::<u8>::from_iter([0, 0])).unwrap();
+    let value = Vector::<u8, 2>::try_from(Vec::<u8>::from_iter([0, 0])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/basic_vector/valid/vec_uint8_2_zero/serialized.ssz_snappy",
@@ -41938,7 +41931,7 @@ fn test_basic_vector_vec_uint_8_2_zero() {
     let recovered_value: Vector<u8, 2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -41982,7 +41975,7 @@ fn test_basic_vector_vec_uint_8_2_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_8_31_max() {
-    let mut value = Vector::<u8, 31>::try_from(Vec::<u8>::from_iter([
+    let value = Vector::<u8, 31>::try_from(Vec::<u8>::from_iter([
         255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
         255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
     ]))
@@ -41996,7 +41989,7 @@ fn test_basic_vector_vec_uint_8_31_max() {
     let recovered_value: Vector<u8, 31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00");
     assert_eq!(root, expected_root);
@@ -42050,7 +42043,7 @@ fn test_basic_vector_vec_uint_8_31_nil() {
 
 #[test]
 fn test_basic_vector_vec_uint_8_31_random() {
-    let mut value = Vector::<u8, 31>::try_from(Vec::<u8>::from_iter([
+    let value = Vector::<u8, 31>::try_from(Vec::<u8>::from_iter([
         170, 73, 242, 193, 85, 27, 39, 254, 83, 38, 110, 73, 13, 177, 56, 72, 156, 232, 20, 213,
         141, 20, 90, 139, 79, 153, 79, 237, 21, 197, 178,
     ]))
@@ -42064,7 +42057,7 @@ fn test_basic_vector_vec_uint_8_31_random() {
     let recovered_value: Vector<u8, 31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xaa49f2c1551b27fe53266e490db138489ce814d58d145a8b4f994fed15c5b200");
     assert_eq!(root, expected_root);
@@ -42108,7 +42101,7 @@ fn test_basic_vector_vec_uint_8_31_random_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_8_31_zero() {
-    let mut value = Vector::<u8, 31>::try_from(Vec::<u8>::from_iter([
+    let value = Vector::<u8, 31>::try_from(Vec::<u8>::from_iter([
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     ]))
     .unwrap();
@@ -42121,7 +42114,7 @@ fn test_basic_vector_vec_uint_8_31_zero() {
     let recovered_value: Vector<u8, 31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -42165,7 +42158,7 @@ fn test_basic_vector_vec_uint_8_31_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_8_3_max() {
-    let mut value = Vector::<u8, 3>::try_from(Vec::<u8>::from_iter([255, 255, 255])).unwrap();
+    let value = Vector::<u8, 3>::try_from(Vec::<u8>::from_iter([255, 255, 255])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/basic_vector/valid/vec_uint8_3_max/serialized.ssz_snappy",
@@ -42175,7 +42168,7 @@ fn test_basic_vector_vec_uint_8_3_max() {
     let recovered_value: Vector<u8, 3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xffffff0000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -42229,7 +42222,7 @@ fn test_basic_vector_vec_uint_8_3_nil() {
 
 #[test]
 fn test_basic_vector_vec_uint_8_3_random() {
-    let mut value = Vector::<u8, 3>::try_from(Vec::<u8>::from_iter([46, 17, 42])).unwrap();
+    let value = Vector::<u8, 3>::try_from(Vec::<u8>::from_iter([46, 17, 42])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/basic_vector/valid/vec_uint8_3_random/serialized.ssz_snappy",
@@ -42239,7 +42232,7 @@ fn test_basic_vector_vec_uint_8_3_random() {
     let recovered_value: Vector<u8, 3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x2e112a0000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -42283,7 +42276,7 @@ fn test_basic_vector_vec_uint_8_3_random_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_8_3_zero() {
-    let mut value = Vector::<u8, 3>::try_from(Vec::<u8>::from_iter([0, 0, 0])).unwrap();
+    let value = Vector::<u8, 3>::try_from(Vec::<u8>::from_iter([0, 0, 0])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/basic_vector/valid/vec_uint8_3_zero/serialized.ssz_snappy",
@@ -42293,7 +42286,7 @@ fn test_basic_vector_vec_uint_8_3_zero() {
     let recovered_value: Vector<u8, 3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -42337,7 +42330,7 @@ fn test_basic_vector_vec_uint_8_3_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_8_4_max() {
-    let mut value = Vector::<u8, 4>::try_from(Vec::<u8>::from_iter([255, 255, 255, 255])).unwrap();
+    let value = Vector::<u8, 4>::try_from(Vec::<u8>::from_iter([255, 255, 255, 255])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/basic_vector/valid/vec_uint8_4_max/serialized.ssz_snappy",
@@ -42347,7 +42340,7 @@ fn test_basic_vector_vec_uint_8_4_max() {
     let recovered_value: Vector<u8, 4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xffffffff00000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -42401,7 +42394,7 @@ fn test_basic_vector_vec_uint_8_4_nil() {
 
 #[test]
 fn test_basic_vector_vec_uint_8_4_random() {
-    let mut value = Vector::<u8, 4>::try_from(Vec::<u8>::from_iter([50, 181, 121, 8])).unwrap();
+    let value = Vector::<u8, 4>::try_from(Vec::<u8>::from_iter([50, 181, 121, 8])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/basic_vector/valid/vec_uint8_4_random/serialized.ssz_snappy",
@@ -42411,7 +42404,7 @@ fn test_basic_vector_vec_uint_8_4_random() {
     let recovered_value: Vector<u8, 4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x32b5790800000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -42455,7 +42448,7 @@ fn test_basic_vector_vec_uint_8_4_random_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_8_4_zero() {
-    let mut value = Vector::<u8, 4>::try_from(Vec::<u8>::from_iter([0, 0, 0, 0])).unwrap();
+    let value = Vector::<u8, 4>::try_from(Vec::<u8>::from_iter([0, 0, 0, 0])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/basic_vector/valid/vec_uint8_4_zero/serialized.ssz_snappy",
@@ -42465,7 +42458,7 @@ fn test_basic_vector_vec_uint_8_4_zero() {
     let recovered_value: Vector<u8, 4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -42509,7 +42502,7 @@ fn test_basic_vector_vec_uint_8_4_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_8_512_max() {
-    let mut value = Vector::<u8, 512>::try_from(Vec::<u8>::from_iter([
+    let value = Vector::<u8, 512>::try_from(Vec::<u8>::from_iter([
         255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
         255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
         255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
@@ -42550,7 +42543,7 @@ fn test_basic_vector_vec_uint_8_512_max() {
     let recovered_value: Vector<u8, 512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x006eed26f731a68917853879507d9fa9f4044f7af999f9df535fac29715db555");
     assert_eq!(root, expected_root);
@@ -42604,7 +42597,7 @@ fn test_basic_vector_vec_uint_8_512_nil() {
 
 #[test]
 fn test_basic_vector_vec_uint_8_512_random() {
-    let mut value = Vector::<u8, 512>::try_from(Vec::<u8>::from_iter([
+    let value = Vector::<u8, 512>::try_from(Vec::<u8>::from_iter([
         253, 174, 239, 243, 23, 241, 87, 225, 224, 151, 140, 63, 95, 213, 223, 61, 52, 248, 192,
         130, 98, 176, 55, 80, 137, 79, 165, 228, 36, 40, 202, 109, 24, 146, 19, 112, 44, 162, 156,
         235, 33, 131, 37, 218, 103, 51, 203, 99, 235, 120, 184, 105, 215, 89, 104, 154, 30, 180,
@@ -42643,7 +42636,7 @@ fn test_basic_vector_vec_uint_8_512_random() {
     let recovered_value: Vector<u8, 512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf4eb96b6673f096fe9ac07abad28b1ae70eeaf6704326b183ed57a02e22933e4");
     assert_eq!(root, expected_root);
@@ -42683,7 +42676,7 @@ fn test_basic_vector_vec_uint_8_512_random_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_8_512_zero() {
-    let mut value = Vector::<u8, 512>::try_from(Vec::<u8>::from_iter([
+    let value = Vector::<u8, 512>::try_from(Vec::<u8>::from_iter([
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -42713,7 +42706,7 @@ fn test_basic_vector_vec_uint_8_512_zero() {
     let recovered_value: Vector<u8, 512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x536d98837f2dd165a55d5eeae91485954472d56f246df256bf3cae19352a123c");
     assert_eq!(root, expected_root);
@@ -42757,7 +42750,7 @@ fn test_basic_vector_vec_uint_8_512_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_8_513_max() {
-    let mut value = Vector::<u8, 513>::try_from(Vec::<u8>::from_iter([
+    let value = Vector::<u8, 513>::try_from(Vec::<u8>::from_iter([
         255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
         255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
         255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
@@ -42798,7 +42791,7 @@ fn test_basic_vector_vec_uint_8_513_max() {
     let recovered_value: Vector<u8, 513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x711318b44d37a71b616d0747647acbe4b8cd24d42a19c6a3ed7b8743adc33bd4");
     assert_eq!(root, expected_root);
@@ -42852,7 +42845,7 @@ fn test_basic_vector_vec_uint_8_513_nil() {
 
 #[test]
 fn test_basic_vector_vec_uint_8_513_random() {
-    let mut value = Vector::<u8, 513>::try_from(Vec::<u8>::from_iter([
+    let value = Vector::<u8, 513>::try_from(Vec::<u8>::from_iter([
         43, 14, 152, 176, 220, 9, 200, 233, 44, 111, 40, 178, 171, 180, 198, 181, 48, 15, 66, 68,
         230, 183, 64, 49, 31, 136, 81, 16, 173, 252, 42, 222, 184, 9, 215, 161, 98, 84, 117, 216,
         87, 221, 255, 71, 194, 243, 197, 156, 141, 132, 73, 183, 67, 133, 159, 127, 151, 85, 79,
@@ -42891,7 +42884,7 @@ fn test_basic_vector_vec_uint_8_513_random() {
     let recovered_value: Vector<u8, 513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xfd0fdfd0c2ccb9a01421e330f2054910070c6b53353a8ddefad470286f00c6f0");
     assert_eq!(root, expected_root);
@@ -42931,7 +42924,7 @@ fn test_basic_vector_vec_uint_8_513_random_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_8_513_zero() {
-    let mut value = Vector::<u8, 513>::try_from(Vec::<u8>::from_iter([
+    let value = Vector::<u8, 513>::try_from(Vec::<u8>::from_iter([
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -42961,7 +42954,7 @@ fn test_basic_vector_vec_uint_8_513_zero() {
     let recovered_value: Vector<u8, 513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x9efde052aa15429fae05bad4d0b1d7c64da64d03d7a1854a588c2cb8430c0d30");
     assert_eq!(root, expected_root);
@@ -43005,8 +42998,7 @@ fn test_basic_vector_vec_uint_8_513_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_8_5_max() {
-    let mut value =
-        Vector::<u8, 5>::try_from(Vec::<u8>::from_iter([255, 255, 255, 255, 255])).unwrap();
+    let value = Vector::<u8, 5>::try_from(Vec::<u8>::from_iter([255, 255, 255, 255, 255])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/basic_vector/valid/vec_uint8_5_max/serialized.ssz_snappy",
@@ -43016,7 +43008,7 @@ fn test_basic_vector_vec_uint_8_5_max() {
     let recovered_value: Vector<u8, 5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xffffffffff000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -43070,8 +43062,7 @@ fn test_basic_vector_vec_uint_8_5_nil() {
 
 #[test]
 fn test_basic_vector_vec_uint_8_5_random() {
-    let mut value =
-        Vector::<u8, 5>::try_from(Vec::<u8>::from_iter([15, 8, 177, 247, 237])).unwrap();
+    let value = Vector::<u8, 5>::try_from(Vec::<u8>::from_iter([15, 8, 177, 247, 237])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/basic_vector/valid/vec_uint8_5_random/serialized.ssz_snappy",
@@ -43081,7 +43072,7 @@ fn test_basic_vector_vec_uint_8_5_random() {
     let recovered_value: Vector<u8, 5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0f08b1f7ed000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -43125,7 +43116,7 @@ fn test_basic_vector_vec_uint_8_5_random_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_8_5_zero() {
-    let mut value = Vector::<u8, 5>::try_from(Vec::<u8>::from_iter([0, 0, 0, 0, 0])).unwrap();
+    let value = Vector::<u8, 5>::try_from(Vec::<u8>::from_iter([0, 0, 0, 0, 0])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/basic_vector/valid/vec_uint8_5_zero/serialized.ssz_snappy",
@@ -43135,7 +43126,7 @@ fn test_basic_vector_vec_uint_8_5_zero() {
     let recovered_value: Vector<u8, 5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -43179,7 +43170,7 @@ fn test_basic_vector_vec_uint_8_5_zero_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_8_8_max() {
-    let mut value =
+    let value =
         Vector::<u8, 8>::try_from(Vec::<u8>::from_iter([255, 255, 255, 255, 255, 255, 255, 255]))
             .unwrap();
     let encoding = serialize(&value);
@@ -43191,7 +43182,7 @@ fn test_basic_vector_vec_uint_8_8_max() {
     let recovered_value: Vector<u8, 8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xffffffffffffffff000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -43245,7 +43236,7 @@ fn test_basic_vector_vec_uint_8_8_nil() {
 
 #[test]
 fn test_basic_vector_vec_uint_8_8_random() {
-    let mut value =
+    let value =
         Vector::<u8, 8>::try_from(Vec::<u8>::from_iter([76, 46, 93, 58, 7, 249, 127, 33])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -43256,7 +43247,7 @@ fn test_basic_vector_vec_uint_8_8_random() {
     let recovered_value: Vector<u8, 8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x4c2e5d3a07f97f21000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -43300,8 +43291,7 @@ fn test_basic_vector_vec_uint_8_8_random_one_more() {
 
 #[test]
 fn test_basic_vector_vec_uint_8_8_zero() {
-    let mut value =
-        Vector::<u8, 8>::try_from(Vec::<u8>::from_iter([0, 0, 0, 0, 0, 0, 0, 0])).unwrap();
+    let value = Vector::<u8, 8>::try_from(Vec::<u8>::from_iter([0, 0, 0, 0, 0, 0, 0, 0])).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/basic_vector/valid/vec_uint8_8_zero/serialized.ssz_snappy",
@@ -43311,7 +43301,7 @@ fn test_basic_vector_vec_uint_8_8_zero() {
     let recovered_value: Vector<u8, 8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);

--- a/ssz-rs/tests/bitlist.rs
+++ b/ssz-rs/tests/bitlist.rs
@@ -8,7 +8,7 @@ use test_utils::{
 
 #[test]
 fn test_bitlist_bitlist_16_lengthy_0() {
-    let mut value =
+    let value =
         <Bitlist<16> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([160, 92, 1]).as_ref())
             .unwrap();
     let encoding = serialize(&value);
@@ -20,7 +20,7 @@ fn test_bitlist_bitlist_16_lengthy_0() {
     let recovered_value: Bitlist<16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x6232812aa34ca3e9ce77374f8915f059832b1671edbbe38e8816196b2be450d5");
     assert_eq!(root, expected_root);
@@ -28,7 +28,7 @@ fn test_bitlist_bitlist_16_lengthy_0() {
 
 #[test]
 fn test_bitlist_bitlist_16_lengthy_1() {
-    let mut value =
+    let value =
         <Bitlist<16> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([64, 179, 1]).as_ref())
             .unwrap();
     let encoding = serialize(&value);
@@ -40,7 +40,7 @@ fn test_bitlist_bitlist_16_lengthy_1() {
     let recovered_value: Bitlist<16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x8c2b7bd1b88a7d1be36dad5c3734873af45f38d2d4618f83211b394aa65a665e");
     assert_eq!(root, expected_root);
@@ -48,7 +48,7 @@ fn test_bitlist_bitlist_16_lengthy_1() {
 
 #[test]
 fn test_bitlist_bitlist_16_lengthy_2() {
-    let mut value =
+    let value =
         <Bitlist<16> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([161, 151, 1]).as_ref())
             .unwrap();
     let encoding = serialize(&value);
@@ -60,7 +60,7 @@ fn test_bitlist_bitlist_16_lengthy_2() {
     let recovered_value: Bitlist<16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xfc0027195d4d241e8d3111d41d749a46f62e2d0e78aa503b856774abe6b7e6c3");
     assert_eq!(root, expected_root);
@@ -68,7 +68,7 @@ fn test_bitlist_bitlist_16_lengthy_2() {
 
 #[test]
 fn test_bitlist_bitlist_16_lengthy_3() {
-    let mut value =
+    let value =
         <Bitlist<16> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([137, 3, 1]).as_ref())
             .unwrap();
     let encoding = serialize(&value);
@@ -80,7 +80,7 @@ fn test_bitlist_bitlist_16_lengthy_3() {
     let recovered_value: Bitlist<16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x50fea858f788bbc2f17f809e05682bf855493a7b8c594f4c2342b469ac7bdb53");
     assert_eq!(root, expected_root);
@@ -88,7 +88,7 @@ fn test_bitlist_bitlist_16_lengthy_3() {
 
 #[test]
 fn test_bitlist_bitlist_16_lengthy_4() {
-    let mut value =
+    let value =
         <Bitlist<16> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([30, 209, 1]).as_ref())
             .unwrap();
     let encoding = serialize(&value);
@@ -100,7 +100,7 @@ fn test_bitlist_bitlist_16_lengthy_4() {
     let recovered_value: Bitlist<16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x983039dcf7ee961e2a2c1b1d0b57ad04491b8674c0f9f6dc326244e48dacd851");
     assert_eq!(root, expected_root);
@@ -108,7 +108,7 @@ fn test_bitlist_bitlist_16_lengthy_4() {
 
 #[test]
 fn test_bitlist_bitlist_16_max_0() {
-    let mut value =
+    let value =
         <Bitlist<16> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([255, 1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -119,7 +119,7 @@ fn test_bitlist_bitlist_16_max_0() {
     let recovered_value: Bitlist<16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x017d2fa0f6934ed2354e4cdb7a2230ccf8f31fe758c7a47442e37fdea1d68bfe");
     assert_eq!(root, expected_root);
@@ -127,7 +127,7 @@ fn test_bitlist_bitlist_16_max_0() {
 
 #[test]
 fn test_bitlist_bitlist_16_max_1() {
-    let mut value =
+    let value =
         <Bitlist<16> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([255, 255, 1]).as_ref())
             .unwrap();
     let encoding = serialize(&value);
@@ -139,7 +139,7 @@ fn test_bitlist_bitlist_16_max_1() {
     let recovered_value: Bitlist<16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xdc8212e2404720c98554dfddc81733f88cbbe307a1d4ca5eae4b88e55e382392");
     assert_eq!(root, expected_root);
@@ -147,7 +147,7 @@ fn test_bitlist_bitlist_16_max_1() {
 
 #[test]
 fn test_bitlist_bitlist_16_max_2() {
-    let mut value =
+    let value =
         <Bitlist<16> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([255, 7]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -158,7 +158,7 @@ fn test_bitlist_bitlist_16_max_2() {
     let recovered_value: Bitlist<16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x5879404f965b9356ffe1e124c2ef7aef85a31eda844aa967aa74d3422a7e2b2e");
     assert_eq!(root, expected_root);
@@ -166,9 +166,8 @@ fn test_bitlist_bitlist_16_max_2() {
 
 #[test]
 fn test_bitlist_bitlist_16_max_3() {
-    let mut value =
-        <Bitlist<16> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([255, 63]).as_ref())
-            .unwrap();
+    let value = <Bitlist<16> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([255, 63]).as_ref())
+        .unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/bitlist/valid/bitlist_16_max_3/serialized.ssz_snappy",
@@ -178,7 +177,7 @@ fn test_bitlist_bitlist_16_max_3() {
     let recovered_value: Bitlist<16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x16472e350c0d8e0cf112307b5cfa66561668ffef5f9f3281c9ad0af85122ba2c");
     assert_eq!(root, expected_root);
@@ -186,7 +185,7 @@ fn test_bitlist_bitlist_16_max_3() {
 
 #[test]
 fn test_bitlist_bitlist_16_max_4() {
-    let mut value =
+    let value =
         <Bitlist<16> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([31]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -197,7 +196,7 @@ fn test_bitlist_bitlist_16_max_4() {
     let recovered_value: Bitlist<16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x4b07c3799db025f3aa92ced1e8545367a2b6e44960f479d3f9d62b61812892d5");
     assert_eq!(root, expected_root);
@@ -205,7 +204,7 @@ fn test_bitlist_bitlist_16_max_4() {
 
 #[test]
 fn test_bitlist_bitlist_16_nil_0() {
-    let mut value =
+    let value =
         <Bitlist<16> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -216,7 +215,7 @@ fn test_bitlist_bitlist_16_nil_0() {
     let recovered_value: Bitlist<16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -224,7 +223,7 @@ fn test_bitlist_bitlist_16_nil_0() {
 
 #[test]
 fn test_bitlist_bitlist_16_nil_1() {
-    let mut value =
+    let value =
         <Bitlist<16> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -235,7 +234,7 @@ fn test_bitlist_bitlist_16_nil_1() {
     let recovered_value: Bitlist<16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -243,7 +242,7 @@ fn test_bitlist_bitlist_16_nil_1() {
 
 #[test]
 fn test_bitlist_bitlist_16_nil_2() {
-    let mut value =
+    let value =
         <Bitlist<16> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -254,7 +253,7 @@ fn test_bitlist_bitlist_16_nil_2() {
     let recovered_value: Bitlist<16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -262,7 +261,7 @@ fn test_bitlist_bitlist_16_nil_2() {
 
 #[test]
 fn test_bitlist_bitlist_16_nil_3() {
-    let mut value =
+    let value =
         <Bitlist<16> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -273,7 +272,7 @@ fn test_bitlist_bitlist_16_nil_3() {
     let recovered_value: Bitlist<16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -281,7 +280,7 @@ fn test_bitlist_bitlist_16_nil_3() {
 
 #[test]
 fn test_bitlist_bitlist_16_nil_4() {
-    let mut value =
+    let value =
         <Bitlist<16> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -292,7 +291,7 @@ fn test_bitlist_bitlist_16_nil_4() {
     let recovered_value: Bitlist<16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -300,7 +299,7 @@ fn test_bitlist_bitlist_16_nil_4() {
 
 #[test]
 fn test_bitlist_bitlist_16_random_0() {
-    let mut value =
+    let value =
         <Bitlist<16> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([180, 3]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -311,7 +310,7 @@ fn test_bitlist_bitlist_16_random_0() {
     let recovered_value: Bitlist<16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xeec57ef94d128f67c545a95b84f97501237ed672f583769110409b2df50bce84");
     assert_eq!(root, expected_root);
@@ -319,7 +318,7 @@ fn test_bitlist_bitlist_16_random_0() {
 
 #[test]
 fn test_bitlist_bitlist_16_random_1() {
-    let mut value =
+    let value =
         <Bitlist<16> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([4]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -330,7 +329,7 @@ fn test_bitlist_bitlist_16_random_1() {
     let recovered_value: Bitlist<16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x1205f4789155711e2542dba1a64d226626fe3eb43baa854752d0b59077e010fc");
     assert_eq!(root, expected_root);
@@ -338,7 +337,7 @@ fn test_bitlist_bitlist_16_random_1() {
 
 #[test]
 fn test_bitlist_bitlist_16_random_2() {
-    let mut value =
+    let value =
         <Bitlist<16> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([59, 1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -349,7 +348,7 @@ fn test_bitlist_bitlist_16_random_2() {
     let recovered_value: Bitlist<16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x8bd00e1a82454504a094276182544df713103259ba3f96133871a55281b44d18");
     assert_eq!(root, expected_root);
@@ -357,9 +356,8 @@ fn test_bitlist_bitlist_16_random_2() {
 
 #[test]
 fn test_bitlist_bitlist_16_random_3() {
-    let mut value =
-        <Bitlist<16> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([104, 23]).as_ref())
-            .unwrap();
+    let value = <Bitlist<16> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([104, 23]).as_ref())
+        .unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/bitlist/valid/bitlist_16_random_3/serialized.ssz_snappy",
@@ -369,7 +367,7 @@ fn test_bitlist_bitlist_16_random_3() {
     let recovered_value: Bitlist<16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x160937bf5c6f4256c285385214969c965a8c841be474c62d7ed3c184ec3cdb69");
     assert_eq!(root, expected_root);
@@ -377,7 +375,7 @@ fn test_bitlist_bitlist_16_random_3() {
 
 #[test]
 fn test_bitlist_bitlist_16_random_4() {
-    let mut value =
+    let value =
         <Bitlist<16> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([25]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -388,7 +386,7 @@ fn test_bitlist_bitlist_16_random_4() {
     let recovered_value: Bitlist<16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x53de69c30b9c07be9cba006e32db34dc1e4ebfe649bc94aa7c8aae0ef419aeed");
     assert_eq!(root, expected_root);
@@ -396,7 +394,7 @@ fn test_bitlist_bitlist_16_random_4() {
 
 #[test]
 fn test_bitlist_bitlist_16_zero_0() {
-    let mut value =
+    let value =
         <Bitlist<16> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0, 64]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -407,7 +405,7 @@ fn test_bitlist_bitlist_16_zero_0() {
     let recovered_value: Bitlist<16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x69713c9ac33bde909bd8763512e69a7f523d544adcfb8c892e24bc8f6341ea16");
     assert_eq!(root, expected_root);
@@ -415,7 +413,7 @@ fn test_bitlist_bitlist_16_zero_0() {
 
 #[test]
 fn test_bitlist_bitlist_16_zero_1() {
-    let mut value =
+    let value =
         <Bitlist<16> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0, 2]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -426,7 +424,7 @@ fn test_bitlist_bitlist_16_zero_1() {
     let recovered_value: Bitlist<16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x7b460f51b362b95b384743dda74f56fbcd35f4d8e7ebda7206632e60c91e663d");
     assert_eq!(root, expected_root);
@@ -434,7 +432,7 @@ fn test_bitlist_bitlist_16_zero_1() {
 
 #[test]
 fn test_bitlist_bitlist_16_zero_2() {
-    let mut value =
+    let value =
         <Bitlist<16> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0, 4]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -445,7 +443,7 @@ fn test_bitlist_bitlist_16_zero_2() {
     let recovered_value: Bitlist<16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xb04cc2cb8ea6754f94c2e7403cf58e20c9023a98350c84282966e0bd6729d3ca");
     assert_eq!(root, expected_root);
@@ -453,7 +451,7 @@ fn test_bitlist_bitlist_16_zero_2() {
 
 #[test]
 fn test_bitlist_bitlist_16_zero_3() {
-    let mut value =
+    let value =
         <Bitlist<16> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([64]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -464,7 +462,7 @@ fn test_bitlist_bitlist_16_zero_3() {
     let recovered_value: Bitlist<16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x7d360196d14b15261c9e5f576df8dc8b48d18d79b4198f167741052747704352");
     assert_eq!(root, expected_root);
@@ -472,9 +470,8 @@ fn test_bitlist_bitlist_16_zero_3() {
 
 #[test]
 fn test_bitlist_bitlist_16_zero_4() {
-    let mut value =
-        <Bitlist<16> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0, 0, 1]).as_ref())
-            .unwrap();
+    let value = <Bitlist<16> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0, 0, 1]).as_ref())
+        .unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/bitlist/valid/bitlist_16_zero_4/serialized.ssz_snappy",
@@ -484,7 +481,7 @@ fn test_bitlist_bitlist_16_zero_4() {
     let recovered_value: Bitlist<16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xa44a029e04493b8d2fe7893391c2b3ceefec1603c585aad6203f2d14e07bfead");
     assert_eq!(root, expected_root);
@@ -522,7 +519,7 @@ fn test_bitlist_bitlist_1_but_9() {
 
 #[test]
 fn test_bitlist_bitlist_1_lengthy_0() {
-    let mut value =
+    let value =
         <Bitlist<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([3]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -533,7 +530,7 @@ fn test_bitlist_bitlist_1_lengthy_0() {
     let recovered_value: Bitlist<1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x56d8a66fbae0300efba7ec2c531973aaae22e7a2ed6ded081b5b32d07a32780a");
     assert_eq!(root, expected_root);
@@ -541,7 +538,7 @@ fn test_bitlist_bitlist_1_lengthy_0() {
 
 #[test]
 fn test_bitlist_bitlist_1_lengthy_1() {
-    let mut value =
+    let value =
         <Bitlist<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([3]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -552,7 +549,7 @@ fn test_bitlist_bitlist_1_lengthy_1() {
     let recovered_value: Bitlist<1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x56d8a66fbae0300efba7ec2c531973aaae22e7a2ed6ded081b5b32d07a32780a");
     assert_eq!(root, expected_root);
@@ -560,7 +557,7 @@ fn test_bitlist_bitlist_1_lengthy_1() {
 
 #[test]
 fn test_bitlist_bitlist_1_lengthy_2() {
-    let mut value =
+    let value =
         <Bitlist<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([2]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -571,7 +568,7 @@ fn test_bitlist_bitlist_1_lengthy_2() {
     let recovered_value: Bitlist<1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xcb592844121d926f1ca3ad4e1d6fb9d8e260ed6e3216361f7732e975a0e8bbf6");
     assert_eq!(root, expected_root);
@@ -579,7 +576,7 @@ fn test_bitlist_bitlist_1_lengthy_2() {
 
 #[test]
 fn test_bitlist_bitlist_1_lengthy_3() {
-    let mut value =
+    let value =
         <Bitlist<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([2]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -590,7 +587,7 @@ fn test_bitlist_bitlist_1_lengthy_3() {
     let recovered_value: Bitlist<1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xcb592844121d926f1ca3ad4e1d6fb9d8e260ed6e3216361f7732e975a0e8bbf6");
     assert_eq!(root, expected_root);
@@ -598,7 +595,7 @@ fn test_bitlist_bitlist_1_lengthy_3() {
 
 #[test]
 fn test_bitlist_bitlist_1_lengthy_4() {
-    let mut value =
+    let value =
         <Bitlist<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([3]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -609,7 +606,7 @@ fn test_bitlist_bitlist_1_lengthy_4() {
     let recovered_value: Bitlist<1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x56d8a66fbae0300efba7ec2c531973aaae22e7a2ed6ded081b5b32d07a32780a");
     assert_eq!(root, expected_root);
@@ -617,7 +614,7 @@ fn test_bitlist_bitlist_1_lengthy_4() {
 
 #[test]
 fn test_bitlist_bitlist_1_max_0() {
-    let mut value =
+    let value =
         <Bitlist<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -628,7 +625,7 @@ fn test_bitlist_bitlist_1_max_0() {
     let recovered_value: Bitlist<1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -636,7 +633,7 @@ fn test_bitlist_bitlist_1_max_0() {
 
 #[test]
 fn test_bitlist_bitlist_1_max_1() {
-    let mut value =
+    let value =
         <Bitlist<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -647,7 +644,7 @@ fn test_bitlist_bitlist_1_max_1() {
     let recovered_value: Bitlist<1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -655,7 +652,7 @@ fn test_bitlist_bitlist_1_max_1() {
 
 #[test]
 fn test_bitlist_bitlist_1_max_2() {
-    let mut value =
+    let value =
         <Bitlist<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -666,7 +663,7 @@ fn test_bitlist_bitlist_1_max_2() {
     let recovered_value: Bitlist<1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -674,7 +671,7 @@ fn test_bitlist_bitlist_1_max_2() {
 
 #[test]
 fn test_bitlist_bitlist_1_max_3() {
-    let mut value =
+    let value =
         <Bitlist<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([3]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -685,7 +682,7 @@ fn test_bitlist_bitlist_1_max_3() {
     let recovered_value: Bitlist<1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x56d8a66fbae0300efba7ec2c531973aaae22e7a2ed6ded081b5b32d07a32780a");
     assert_eq!(root, expected_root);
@@ -693,7 +690,7 @@ fn test_bitlist_bitlist_1_max_3() {
 
 #[test]
 fn test_bitlist_bitlist_1_max_4() {
-    let mut value =
+    let value =
         <Bitlist<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([3]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -704,7 +701,7 @@ fn test_bitlist_bitlist_1_max_4() {
     let recovered_value: Bitlist<1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x56d8a66fbae0300efba7ec2c531973aaae22e7a2ed6ded081b5b32d07a32780a");
     assert_eq!(root, expected_root);
@@ -712,7 +709,7 @@ fn test_bitlist_bitlist_1_max_4() {
 
 #[test]
 fn test_bitlist_bitlist_1_nil_0() {
-    let mut value =
+    let value =
         <Bitlist<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -723,7 +720,7 @@ fn test_bitlist_bitlist_1_nil_0() {
     let recovered_value: Bitlist<1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -731,7 +728,7 @@ fn test_bitlist_bitlist_1_nil_0() {
 
 #[test]
 fn test_bitlist_bitlist_1_nil_1() {
-    let mut value =
+    let value =
         <Bitlist<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -742,7 +739,7 @@ fn test_bitlist_bitlist_1_nil_1() {
     let recovered_value: Bitlist<1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -750,7 +747,7 @@ fn test_bitlist_bitlist_1_nil_1() {
 
 #[test]
 fn test_bitlist_bitlist_1_nil_2() {
-    let mut value =
+    let value =
         <Bitlist<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -761,7 +758,7 @@ fn test_bitlist_bitlist_1_nil_2() {
     let recovered_value: Bitlist<1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -769,7 +766,7 @@ fn test_bitlist_bitlist_1_nil_2() {
 
 #[test]
 fn test_bitlist_bitlist_1_nil_3() {
-    let mut value =
+    let value =
         <Bitlist<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -780,7 +777,7 @@ fn test_bitlist_bitlist_1_nil_3() {
     let recovered_value: Bitlist<1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -788,7 +785,7 @@ fn test_bitlist_bitlist_1_nil_3() {
 
 #[test]
 fn test_bitlist_bitlist_1_nil_4() {
-    let mut value =
+    let value =
         <Bitlist<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -799,7 +796,7 @@ fn test_bitlist_bitlist_1_nil_4() {
     let recovered_value: Bitlist<1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -807,7 +804,7 @@ fn test_bitlist_bitlist_1_nil_4() {
 
 #[test]
 fn test_bitlist_bitlist_1_random_0() {
-    let mut value =
+    let value =
         <Bitlist<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -818,7 +815,7 @@ fn test_bitlist_bitlist_1_random_0() {
     let recovered_value: Bitlist<1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -826,7 +823,7 @@ fn test_bitlist_bitlist_1_random_0() {
 
 #[test]
 fn test_bitlist_bitlist_1_random_1() {
-    let mut value =
+    let value =
         <Bitlist<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -837,7 +834,7 @@ fn test_bitlist_bitlist_1_random_1() {
     let recovered_value: Bitlist<1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -845,7 +842,7 @@ fn test_bitlist_bitlist_1_random_1() {
 
 #[test]
 fn test_bitlist_bitlist_1_random_2() {
-    let mut value =
+    let value =
         <Bitlist<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -856,7 +853,7 @@ fn test_bitlist_bitlist_1_random_2() {
     let recovered_value: Bitlist<1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -864,7 +861,7 @@ fn test_bitlist_bitlist_1_random_2() {
 
 #[test]
 fn test_bitlist_bitlist_1_random_3() {
-    let mut value =
+    let value =
         <Bitlist<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -875,7 +872,7 @@ fn test_bitlist_bitlist_1_random_3() {
     let recovered_value: Bitlist<1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -883,7 +880,7 @@ fn test_bitlist_bitlist_1_random_3() {
 
 #[test]
 fn test_bitlist_bitlist_1_random_4() {
-    let mut value =
+    let value =
         <Bitlist<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([3]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -894,7 +891,7 @@ fn test_bitlist_bitlist_1_random_4() {
     let recovered_value: Bitlist<1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x56d8a66fbae0300efba7ec2c531973aaae22e7a2ed6ded081b5b32d07a32780a");
     assert_eq!(root, expected_root);
@@ -902,7 +899,7 @@ fn test_bitlist_bitlist_1_random_4() {
 
 #[test]
 fn test_bitlist_bitlist_1_zero_0() {
-    let mut value =
+    let value =
         <Bitlist<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -913,7 +910,7 @@ fn test_bitlist_bitlist_1_zero_0() {
     let recovered_value: Bitlist<1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -921,7 +918,7 @@ fn test_bitlist_bitlist_1_zero_0() {
 
 #[test]
 fn test_bitlist_bitlist_1_zero_1() {
-    let mut value =
+    let value =
         <Bitlist<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -932,7 +929,7 @@ fn test_bitlist_bitlist_1_zero_1() {
     let recovered_value: Bitlist<1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -940,7 +937,7 @@ fn test_bitlist_bitlist_1_zero_1() {
 
 #[test]
 fn test_bitlist_bitlist_1_zero_2() {
-    let mut value =
+    let value =
         <Bitlist<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -951,7 +948,7 @@ fn test_bitlist_bitlist_1_zero_2() {
     let recovered_value: Bitlist<1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -959,7 +956,7 @@ fn test_bitlist_bitlist_1_zero_2() {
 
 #[test]
 fn test_bitlist_bitlist_1_zero_3() {
-    let mut value =
+    let value =
         <Bitlist<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -970,7 +967,7 @@ fn test_bitlist_bitlist_1_zero_3() {
     let recovered_value: Bitlist<1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -978,7 +975,7 @@ fn test_bitlist_bitlist_1_zero_3() {
 
 #[test]
 fn test_bitlist_bitlist_1_zero_4() {
-    let mut value =
+    let value =
         <Bitlist<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([2]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -989,7 +986,7 @@ fn test_bitlist_bitlist_1_zero_4() {
     let recovered_value: Bitlist<1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xcb592844121d926f1ca3ad4e1d6fb9d8e260ed6e3216361f7732e975a0e8bbf6");
     assert_eq!(root, expected_root);
@@ -1007,7 +1004,7 @@ fn test_bitlist_bitlist_2_but_3() {
 
 #[test]
 fn test_bitlist_bitlist_2_lengthy_0() {
-    let mut value =
+    let value =
         <Bitlist<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([7]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -1018,7 +1015,7 @@ fn test_bitlist_bitlist_2_lengthy_0() {
     let recovered_value: Bitlist<2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xc397e31994d6b872c69af43765ab16a1cef673be726a820dacd2637bea2f5fbb");
     assert_eq!(root, expected_root);
@@ -1026,7 +1023,7 @@ fn test_bitlist_bitlist_2_lengthy_0() {
 
 #[test]
 fn test_bitlist_bitlist_2_lengthy_1() {
-    let mut value =
+    let value =
         <Bitlist<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([5]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -1037,7 +1034,7 @@ fn test_bitlist_bitlist_2_lengthy_1() {
     let recovered_value: Bitlist<2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xff55c97976a840b4ced964ed49e3794594ba3f675238b5fd25d282b60f70a194");
     assert_eq!(root, expected_root);
@@ -1045,7 +1042,7 @@ fn test_bitlist_bitlist_2_lengthy_1() {
 
 #[test]
 fn test_bitlist_bitlist_2_lengthy_2() {
-    let mut value =
+    let value =
         <Bitlist<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([7]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -1056,7 +1053,7 @@ fn test_bitlist_bitlist_2_lengthy_2() {
     let recovered_value: Bitlist<2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xc397e31994d6b872c69af43765ab16a1cef673be726a820dacd2637bea2f5fbb");
     assert_eq!(root, expected_root);
@@ -1064,7 +1061,7 @@ fn test_bitlist_bitlist_2_lengthy_2() {
 
 #[test]
 fn test_bitlist_bitlist_2_lengthy_3() {
-    let mut value =
+    let value =
         <Bitlist<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([5]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -1075,7 +1072,7 @@ fn test_bitlist_bitlist_2_lengthy_3() {
     let recovered_value: Bitlist<2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xff55c97976a840b4ced964ed49e3794594ba3f675238b5fd25d282b60f70a194");
     assert_eq!(root, expected_root);
@@ -1083,7 +1080,7 @@ fn test_bitlist_bitlist_2_lengthy_3() {
 
 #[test]
 fn test_bitlist_bitlist_2_lengthy_4() {
-    let mut value =
+    let value =
         <Bitlist<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([5]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -1094,7 +1091,7 @@ fn test_bitlist_bitlist_2_lengthy_4() {
     let recovered_value: Bitlist<2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xff55c97976a840b4ced964ed49e3794594ba3f675238b5fd25d282b60f70a194");
     assert_eq!(root, expected_root);
@@ -1102,7 +1099,7 @@ fn test_bitlist_bitlist_2_lengthy_4() {
 
 #[test]
 fn test_bitlist_bitlist_2_max_0() {
-    let mut value =
+    let value =
         <Bitlist<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -1113,7 +1110,7 @@ fn test_bitlist_bitlist_2_max_0() {
     let recovered_value: Bitlist<2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -1121,7 +1118,7 @@ fn test_bitlist_bitlist_2_max_0() {
 
 #[test]
 fn test_bitlist_bitlist_2_max_1() {
-    let mut value =
+    let value =
         <Bitlist<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -1132,7 +1129,7 @@ fn test_bitlist_bitlist_2_max_1() {
     let recovered_value: Bitlist<2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -1140,7 +1137,7 @@ fn test_bitlist_bitlist_2_max_1() {
 
 #[test]
 fn test_bitlist_bitlist_2_max_2() {
-    let mut value =
+    let value =
         <Bitlist<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([3]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -1151,7 +1148,7 @@ fn test_bitlist_bitlist_2_max_2() {
     let recovered_value: Bitlist<2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x56d8a66fbae0300efba7ec2c531973aaae22e7a2ed6ded081b5b32d07a32780a");
     assert_eq!(root, expected_root);
@@ -1159,7 +1156,7 @@ fn test_bitlist_bitlist_2_max_2() {
 
 #[test]
 fn test_bitlist_bitlist_2_max_3() {
-    let mut value =
+    let value =
         <Bitlist<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([3]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -1170,7 +1167,7 @@ fn test_bitlist_bitlist_2_max_3() {
     let recovered_value: Bitlist<2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x56d8a66fbae0300efba7ec2c531973aaae22e7a2ed6ded081b5b32d07a32780a");
     assert_eq!(root, expected_root);
@@ -1178,7 +1175,7 @@ fn test_bitlist_bitlist_2_max_3() {
 
 #[test]
 fn test_bitlist_bitlist_2_max_4() {
-    let mut value =
+    let value =
         <Bitlist<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -1189,7 +1186,7 @@ fn test_bitlist_bitlist_2_max_4() {
     let recovered_value: Bitlist<2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -1197,7 +1194,7 @@ fn test_bitlist_bitlist_2_max_4() {
 
 #[test]
 fn test_bitlist_bitlist_2_nil_0() {
-    let mut value =
+    let value =
         <Bitlist<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -1208,7 +1205,7 @@ fn test_bitlist_bitlist_2_nil_0() {
     let recovered_value: Bitlist<2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -1216,7 +1213,7 @@ fn test_bitlist_bitlist_2_nil_0() {
 
 #[test]
 fn test_bitlist_bitlist_2_nil_1() {
-    let mut value =
+    let value =
         <Bitlist<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -1227,7 +1224,7 @@ fn test_bitlist_bitlist_2_nil_1() {
     let recovered_value: Bitlist<2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -1235,7 +1232,7 @@ fn test_bitlist_bitlist_2_nil_1() {
 
 #[test]
 fn test_bitlist_bitlist_2_nil_2() {
-    let mut value =
+    let value =
         <Bitlist<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -1246,7 +1243,7 @@ fn test_bitlist_bitlist_2_nil_2() {
     let recovered_value: Bitlist<2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -1254,7 +1251,7 @@ fn test_bitlist_bitlist_2_nil_2() {
 
 #[test]
 fn test_bitlist_bitlist_2_nil_3() {
-    let mut value =
+    let value =
         <Bitlist<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -1265,7 +1262,7 @@ fn test_bitlist_bitlist_2_nil_3() {
     let recovered_value: Bitlist<2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -1273,7 +1270,7 @@ fn test_bitlist_bitlist_2_nil_3() {
 
 #[test]
 fn test_bitlist_bitlist_2_nil_4() {
-    let mut value =
+    let value =
         <Bitlist<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -1284,7 +1281,7 @@ fn test_bitlist_bitlist_2_nil_4() {
     let recovered_value: Bitlist<2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -1292,7 +1289,7 @@ fn test_bitlist_bitlist_2_nil_4() {
 
 #[test]
 fn test_bitlist_bitlist_2_random_0() {
-    let mut value =
+    let value =
         <Bitlist<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([3]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -1303,7 +1300,7 @@ fn test_bitlist_bitlist_2_random_0() {
     let recovered_value: Bitlist<2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x56d8a66fbae0300efba7ec2c531973aaae22e7a2ed6ded081b5b32d07a32780a");
     assert_eq!(root, expected_root);
@@ -1311,7 +1308,7 @@ fn test_bitlist_bitlist_2_random_0() {
 
 #[test]
 fn test_bitlist_bitlist_2_random_1() {
-    let mut value =
+    let value =
         <Bitlist<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([6]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -1322,7 +1319,7 @@ fn test_bitlist_bitlist_2_random_1() {
     let recovered_value: Bitlist<2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0e01f8d9a6720610a44a70c2c91bbe750ec6cd67892d92b1016394abfc382cf9");
     assert_eq!(root, expected_root);
@@ -1330,7 +1327,7 @@ fn test_bitlist_bitlist_2_random_1() {
 
 #[test]
 fn test_bitlist_bitlist_2_random_2() {
-    let mut value =
+    let value =
         <Bitlist<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([7]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -1341,7 +1338,7 @@ fn test_bitlist_bitlist_2_random_2() {
     let recovered_value: Bitlist<2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xc397e31994d6b872c69af43765ab16a1cef673be726a820dacd2637bea2f5fbb");
     assert_eq!(root, expected_root);
@@ -1349,7 +1346,7 @@ fn test_bitlist_bitlist_2_random_2() {
 
 #[test]
 fn test_bitlist_bitlist_2_random_3() {
-    let mut value =
+    let value =
         <Bitlist<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([3]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -1360,7 +1357,7 @@ fn test_bitlist_bitlist_2_random_3() {
     let recovered_value: Bitlist<2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x56d8a66fbae0300efba7ec2c531973aaae22e7a2ed6ded081b5b32d07a32780a");
     assert_eq!(root, expected_root);
@@ -1368,7 +1365,7 @@ fn test_bitlist_bitlist_2_random_3() {
 
 #[test]
 fn test_bitlist_bitlist_2_random_4() {
-    let mut value =
+    let value =
         <Bitlist<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -1379,7 +1376,7 @@ fn test_bitlist_bitlist_2_random_4() {
     let recovered_value: Bitlist<2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -1387,7 +1384,7 @@ fn test_bitlist_bitlist_2_random_4() {
 
 #[test]
 fn test_bitlist_bitlist_2_zero_0() {
-    let mut value =
+    let value =
         <Bitlist<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([4]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -1398,7 +1395,7 @@ fn test_bitlist_bitlist_2_zero_0() {
     let recovered_value: Bitlist<2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x1205f4789155711e2542dba1a64d226626fe3eb43baa854752d0b59077e010fc");
     assert_eq!(root, expected_root);
@@ -1406,7 +1403,7 @@ fn test_bitlist_bitlist_2_zero_0() {
 
 #[test]
 fn test_bitlist_bitlist_2_zero_1() {
-    let mut value =
+    let value =
         <Bitlist<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -1417,7 +1414,7 @@ fn test_bitlist_bitlist_2_zero_1() {
     let recovered_value: Bitlist<2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -1425,7 +1422,7 @@ fn test_bitlist_bitlist_2_zero_1() {
 
 #[test]
 fn test_bitlist_bitlist_2_zero_2() {
-    let mut value =
+    let value =
         <Bitlist<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -1436,7 +1433,7 @@ fn test_bitlist_bitlist_2_zero_2() {
     let recovered_value: Bitlist<2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -1444,7 +1441,7 @@ fn test_bitlist_bitlist_2_zero_2() {
 
 #[test]
 fn test_bitlist_bitlist_2_zero_3() {
-    let mut value =
+    let value =
         <Bitlist<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([2]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -1455,7 +1452,7 @@ fn test_bitlist_bitlist_2_zero_3() {
     let recovered_value: Bitlist<2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xcb592844121d926f1ca3ad4e1d6fb9d8e260ed6e3216361f7732e975a0e8bbf6");
     assert_eq!(root, expected_root);
@@ -1463,7 +1460,7 @@ fn test_bitlist_bitlist_2_zero_3() {
 
 #[test]
 fn test_bitlist_bitlist_2_zero_4() {
-    let mut value =
+    let value =
         <Bitlist<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([2]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -1474,7 +1471,7 @@ fn test_bitlist_bitlist_2_zero_4() {
     let recovered_value: Bitlist<2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xcb592844121d926f1ca3ad4e1d6fb9d8e260ed6e3216361f7732e975a0e8bbf6");
     assert_eq!(root, expected_root);
@@ -1482,7 +1479,7 @@ fn test_bitlist_bitlist_2_zero_4() {
 
 #[test]
 fn test_bitlist_bitlist_31_lengthy_0() {
-    let mut value = <Bitlist<31> as TryFrom<&[u8]>>::try_from(
+    let value = <Bitlist<31> as TryFrom<&[u8]>>::try_from(
         Vec::<u8>::from_iter([4, 107, 245, 244]).as_ref(),
     )
     .unwrap();
@@ -1495,7 +1492,7 @@ fn test_bitlist_bitlist_31_lengthy_0() {
     let recovered_value: Bitlist<31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x2b4e175a3cabe516e47026098d7a07a105d94c6e1d7859c5f8e99d81d5fb73e5");
     assert_eq!(root, expected_root);
@@ -1503,7 +1500,7 @@ fn test_bitlist_bitlist_31_lengthy_0() {
 
 #[test]
 fn test_bitlist_bitlist_31_lengthy_1() {
-    let mut value = <Bitlist<31> as TryFrom<&[u8]>>::try_from(
+    let value = <Bitlist<31> as TryFrom<&[u8]>>::try_from(
         Vec::<u8>::from_iter([16, 43, 211, 221]).as_ref(),
     )
     .unwrap();
@@ -1516,7 +1513,7 @@ fn test_bitlist_bitlist_31_lengthy_1() {
     let recovered_value: Bitlist<31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5054e572357a7c57c9f05e8f79208348c9dfe9f28461d7935700459b1ae2307");
     assert_eq!(root, expected_root);
@@ -1524,7 +1521,7 @@ fn test_bitlist_bitlist_31_lengthy_1() {
 
 #[test]
 fn test_bitlist_bitlist_31_lengthy_2() {
-    let mut value = <Bitlist<31> as TryFrom<&[u8]>>::try_from(
+    let value = <Bitlist<31> as TryFrom<&[u8]>>::try_from(
         Vec::<u8>::from_iter([149, 146, 83, 204]).as_ref(),
     )
     .unwrap();
@@ -1537,7 +1534,7 @@ fn test_bitlist_bitlist_31_lengthy_2() {
     let recovered_value: Bitlist<31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x57bdf36005bb9113c2b89db95c10946d97609b3173d4397a1a74755d0c6490f8");
     assert_eq!(root, expected_root);
@@ -1545,7 +1542,7 @@ fn test_bitlist_bitlist_31_lengthy_2() {
 
 #[test]
 fn test_bitlist_bitlist_31_lengthy_3() {
-    let mut value = <Bitlist<31> as TryFrom<&[u8]>>::try_from(
+    let value = <Bitlist<31> as TryFrom<&[u8]>>::try_from(
         Vec::<u8>::from_iter([188, 71, 14, 158]).as_ref(),
     )
     .unwrap();
@@ -1558,7 +1555,7 @@ fn test_bitlist_bitlist_31_lengthy_3() {
     let recovered_value: Bitlist<31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0faa1049c965bf5a37db3b457dcc3a2ee179ef704c42a29722641b2ec3bb3658");
     assert_eq!(root, expected_root);
@@ -1566,7 +1563,7 @@ fn test_bitlist_bitlist_31_lengthy_3() {
 
 #[test]
 fn test_bitlist_bitlist_31_lengthy_4() {
-    let mut value = <Bitlist<31> as TryFrom<&[u8]>>::try_from(
+    let value = <Bitlist<31> as TryFrom<&[u8]>>::try_from(
         Vec::<u8>::from_iter([46, 129, 210, 162]).as_ref(),
     )
     .unwrap();
@@ -1579,7 +1576,7 @@ fn test_bitlist_bitlist_31_lengthy_4() {
     let recovered_value: Bitlist<31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x152b52ebbfc701c7a39758748e1f14b4361ae37dd480b6914aa725824cde97f2");
     assert_eq!(root, expected_root);
@@ -1587,7 +1584,7 @@ fn test_bitlist_bitlist_31_lengthy_4() {
 
 #[test]
 fn test_bitlist_bitlist_31_max_0() {
-    let mut value =
+    let value =
         <Bitlist<31> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([255, 255]).as_ref())
             .unwrap();
     let encoding = serialize(&value);
@@ -1599,7 +1596,7 @@ fn test_bitlist_bitlist_31_max_0() {
     let recovered_value: Bitlist<31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xebe018d5287ea5be7d789946da9587c27f5dd82d8c120a594ae0e8ddd2e21802");
     assert_eq!(root, expected_root);
@@ -1607,7 +1604,7 @@ fn test_bitlist_bitlist_31_max_0() {
 
 #[test]
 fn test_bitlist_bitlist_31_max_1() {
-    let mut value =
+    let value =
         <Bitlist<31> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([3]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -1618,7 +1615,7 @@ fn test_bitlist_bitlist_31_max_1() {
     let recovered_value: Bitlist<31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x56d8a66fbae0300efba7ec2c531973aaae22e7a2ed6ded081b5b32d07a32780a");
     assert_eq!(root, expected_root);
@@ -1626,7 +1623,7 @@ fn test_bitlist_bitlist_31_max_1() {
 
 #[test]
 fn test_bitlist_bitlist_31_max_2() {
-    let mut value = <Bitlist<31> as TryFrom<&[u8]>>::try_from(
+    let value = <Bitlist<31> as TryFrom<&[u8]>>::try_from(
         Vec::<u8>::from_iter([255, 255, 255, 3]).as_ref(),
     )
     .unwrap();
@@ -1639,7 +1636,7 @@ fn test_bitlist_bitlist_31_max_2() {
     let recovered_value: Bitlist<31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xe78c29807c3f3ced69109d22d734a1c69d361e0671c21b8681a1761333e95537");
     assert_eq!(root, expected_root);
@@ -1647,7 +1644,7 @@ fn test_bitlist_bitlist_31_max_2() {
 
 #[test]
 fn test_bitlist_bitlist_31_max_3() {
-    let mut value =
+    let value =
         <Bitlist<31> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([255, 255, 255]).as_ref())
             .unwrap();
     let encoding = serialize(&value);
@@ -1659,7 +1656,7 @@ fn test_bitlist_bitlist_31_max_3() {
     let recovered_value: Bitlist<31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xb8570b9c932d5fd3d2bd727a64d527f790d8261acd9f6ce2786cc1fa34dd2fa8");
     assert_eq!(root, expected_root);
@@ -1667,9 +1664,8 @@ fn test_bitlist_bitlist_31_max_3() {
 
 #[test]
 fn test_bitlist_bitlist_31_max_4() {
-    let mut value =
-        <Bitlist<31> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([255, 31]).as_ref())
-            .unwrap();
+    let value = <Bitlist<31> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([255, 31]).as_ref())
+        .unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/bitlist/valid/bitlist_31_max_4/serialized.ssz_snappy",
@@ -1679,7 +1675,7 @@ fn test_bitlist_bitlist_31_max_4() {
     let recovered_value: Bitlist<31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x4b5bcf109d8b0381e1ca551794c9fb864838f5b07057e05da75830f7999d96de");
     assert_eq!(root, expected_root);
@@ -1687,7 +1683,7 @@ fn test_bitlist_bitlist_31_max_4() {
 
 #[test]
 fn test_bitlist_bitlist_31_nil_0() {
-    let mut value =
+    let value =
         <Bitlist<31> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -1698,7 +1694,7 @@ fn test_bitlist_bitlist_31_nil_0() {
     let recovered_value: Bitlist<31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -1706,7 +1702,7 @@ fn test_bitlist_bitlist_31_nil_0() {
 
 #[test]
 fn test_bitlist_bitlist_31_nil_1() {
-    let mut value =
+    let value =
         <Bitlist<31> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -1717,7 +1713,7 @@ fn test_bitlist_bitlist_31_nil_1() {
     let recovered_value: Bitlist<31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -1725,7 +1721,7 @@ fn test_bitlist_bitlist_31_nil_1() {
 
 #[test]
 fn test_bitlist_bitlist_31_nil_2() {
-    let mut value =
+    let value =
         <Bitlist<31> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -1736,7 +1732,7 @@ fn test_bitlist_bitlist_31_nil_2() {
     let recovered_value: Bitlist<31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -1744,7 +1740,7 @@ fn test_bitlist_bitlist_31_nil_2() {
 
 #[test]
 fn test_bitlist_bitlist_31_nil_3() {
-    let mut value =
+    let value =
         <Bitlist<31> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -1755,7 +1751,7 @@ fn test_bitlist_bitlist_31_nil_3() {
     let recovered_value: Bitlist<31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -1763,7 +1759,7 @@ fn test_bitlist_bitlist_31_nil_3() {
 
 #[test]
 fn test_bitlist_bitlist_31_nil_4() {
-    let mut value =
+    let value =
         <Bitlist<31> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -1774,7 +1770,7 @@ fn test_bitlist_bitlist_31_nil_4() {
     let recovered_value: Bitlist<31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -1782,7 +1778,7 @@ fn test_bitlist_bitlist_31_nil_4() {
 
 #[test]
 fn test_bitlist_bitlist_31_random_0() {
-    let mut value =
+    let value =
         <Bitlist<31> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([2]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -1793,7 +1789,7 @@ fn test_bitlist_bitlist_31_random_0() {
     let recovered_value: Bitlist<31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xcb592844121d926f1ca3ad4e1d6fb9d8e260ed6e3216361f7732e975a0e8bbf6");
     assert_eq!(root, expected_root);
@@ -1801,7 +1797,7 @@ fn test_bitlist_bitlist_31_random_0() {
 
 #[test]
 fn test_bitlist_bitlist_31_random_1() {
-    let mut value =
+    let value =
         <Bitlist<31> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([106, 1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -1812,7 +1808,7 @@ fn test_bitlist_bitlist_31_random_1() {
     let recovered_value: Bitlist<31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x62681102fbb14f3973d9db3e302be35e5bbd79984aed6a85c532c63189afb38a");
     assert_eq!(root, expected_root);
@@ -1820,7 +1816,7 @@ fn test_bitlist_bitlist_31_random_1() {
 
 #[test]
 fn test_bitlist_bitlist_31_random_2() {
-    let mut value = <Bitlist<31> as TryFrom<&[u8]>>::try_from(
+    let value = <Bitlist<31> as TryFrom<&[u8]>>::try_from(
         Vec::<u8>::from_iter([106, 141, 117, 7]).as_ref(),
     )
     .unwrap();
@@ -1833,7 +1829,7 @@ fn test_bitlist_bitlist_31_random_2() {
     let recovered_value: Bitlist<31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x1037ee25750a944efe9b3dc796628f6468a9f242bd791013c439ca785c134482");
     assert_eq!(root, expected_root);
@@ -1841,7 +1837,7 @@ fn test_bitlist_bitlist_31_random_2() {
 
 #[test]
 fn test_bitlist_bitlist_31_random_3() {
-    let mut value =
+    let value =
         <Bitlist<31> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([155, 1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -1852,7 +1848,7 @@ fn test_bitlist_bitlist_31_random_3() {
     let recovered_value: Bitlist<31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x5940967aaa293730d0e7876047dfceb9cf5512fafb5d4be3d05c776902163786");
     assert_eq!(root, expected_root);
@@ -1860,7 +1856,7 @@ fn test_bitlist_bitlist_31_random_3() {
 
 #[test]
 fn test_bitlist_bitlist_31_random_4() {
-    let mut value =
+    let value =
         <Bitlist<31> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -1871,7 +1867,7 @@ fn test_bitlist_bitlist_31_random_4() {
     let recovered_value: Bitlist<31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -1879,7 +1875,7 @@ fn test_bitlist_bitlist_31_random_4() {
 
 #[test]
 fn test_bitlist_bitlist_31_zero_0() {
-    let mut value =
+    let value =
         <Bitlist<31> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0, 0, 0, 16]).as_ref())
             .unwrap();
     let encoding = serialize(&value);
@@ -1891,7 +1887,7 @@ fn test_bitlist_bitlist_31_zero_0() {
     let recovered_value: Bitlist<31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x6463f4376faab07e62e5a4737d2d95ad690892f8fae0b9559c0ed3ae96bb2790");
     assert_eq!(root, expected_root);
@@ -1899,7 +1895,7 @@ fn test_bitlist_bitlist_31_zero_0() {
 
 #[test]
 fn test_bitlist_bitlist_31_zero_1() {
-    let mut value =
+    let value =
         <Bitlist<31> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0, 0, 0, 64]).as_ref())
             .unwrap();
     let encoding = serialize(&value);
@@ -1911,7 +1907,7 @@ fn test_bitlist_bitlist_31_zero_1() {
     let recovered_value: Bitlist<31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x7d934ef6667cff3afea0633d57baa9a82a7009f89b0f8c12f47150047098b396");
     assert_eq!(root, expected_root);
@@ -1919,9 +1915,8 @@ fn test_bitlist_bitlist_31_zero_1() {
 
 #[test]
 fn test_bitlist_bitlist_31_zero_2() {
-    let mut value =
-        <Bitlist<31> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0, 0, 2]).as_ref())
-            .unwrap();
+    let value = <Bitlist<31> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0, 0, 2]).as_ref())
+        .unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/bitlist/valid/bitlist_31_zero_2/serialized.ssz_snappy",
@@ -1931,7 +1926,7 @@ fn test_bitlist_bitlist_31_zero_2() {
     let recovered_value: Bitlist<31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x967293ee9d7ba679c3ef076bef139e2ceb96d45d19a624cc59bb5a3c1649ce38");
     assert_eq!(root, expected_root);
@@ -1939,7 +1934,7 @@ fn test_bitlist_bitlist_31_zero_2() {
 
 #[test]
 fn test_bitlist_bitlist_31_zero_3() {
-    let mut value =
+    let value =
         <Bitlist<31> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0, 0, 0, 8]).as_ref())
             .unwrap();
     let encoding = serialize(&value);
@@ -1951,7 +1946,7 @@ fn test_bitlist_bitlist_31_zero_3() {
     let recovered_value: Bitlist<31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x04997ec49450b710d4d92e2e6e92c47b193b0ec6f841d7d692bf0f410cbc7269");
     assert_eq!(root, expected_root);
@@ -1959,7 +1954,7 @@ fn test_bitlist_bitlist_31_zero_3() {
 
 #[test]
 fn test_bitlist_bitlist_31_zero_4() {
-    let mut value =
+    let value =
         <Bitlist<31> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([4]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -1970,7 +1965,7 @@ fn test_bitlist_bitlist_31_zero_4() {
     let recovered_value: Bitlist<31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x1205f4789155711e2542dba1a64d226626fe3eb43baa854752d0b59077e010fc");
     assert_eq!(root, expected_root);
@@ -2008,7 +2003,7 @@ fn test_bitlist_bitlist_3_but_4() {
 
 #[test]
 fn test_bitlist_bitlist_3_lengthy_0() {
-    let mut value =
+    let value =
         <Bitlist<3> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([8]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -2019,7 +2014,7 @@ fn test_bitlist_bitlist_3_lengthy_0() {
     let recovered_value: Bitlist<3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xd86ae2ca925345bf2412bde450ac175742d979c1ea7b961bd1efe10beb9500cf");
     assert_eq!(root, expected_root);
@@ -2027,7 +2022,7 @@ fn test_bitlist_bitlist_3_lengthy_0() {
 
 #[test]
 fn test_bitlist_bitlist_3_lengthy_1() {
-    let mut value =
+    let value =
         <Bitlist<3> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([8]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -2038,7 +2033,7 @@ fn test_bitlist_bitlist_3_lengthy_1() {
     let recovered_value: Bitlist<3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xd86ae2ca925345bf2412bde450ac175742d979c1ea7b961bd1efe10beb9500cf");
     assert_eq!(root, expected_root);
@@ -2046,7 +2041,7 @@ fn test_bitlist_bitlist_3_lengthy_1() {
 
 #[test]
 fn test_bitlist_bitlist_3_lengthy_2() {
-    let mut value =
+    let value =
         <Bitlist<3> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([9]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -2057,7 +2052,7 @@ fn test_bitlist_bitlist_3_lengthy_2() {
     let recovered_value: Bitlist<3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xcaea92341df83aa8d4225099f16e86cbf457ec7ea97ccddb4ba5560062eee695");
     assert_eq!(root, expected_root);
@@ -2065,7 +2060,7 @@ fn test_bitlist_bitlist_3_lengthy_2() {
 
 #[test]
 fn test_bitlist_bitlist_3_lengthy_3() {
-    let mut value =
+    let value =
         <Bitlist<3> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([12]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -2076,7 +2071,7 @@ fn test_bitlist_bitlist_3_lengthy_3() {
     let recovered_value: Bitlist<3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xd3156136ef0ebd0cb8945f7c18cfe8ad539d08d8703744bc11371e49e6a4d9ad");
     assert_eq!(root, expected_root);
@@ -2084,7 +2079,7 @@ fn test_bitlist_bitlist_3_lengthy_3() {
 
 #[test]
 fn test_bitlist_bitlist_3_lengthy_4() {
-    let mut value =
+    let value =
         <Bitlist<3> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([15]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -2095,7 +2090,7 @@ fn test_bitlist_bitlist_3_lengthy_4() {
     let recovered_value: Bitlist<3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x251d8bd955c85219bb8f6de682810b4aafe3e0c3d3c624020fb39f81dbb85910");
     assert_eq!(root, expected_root);
@@ -2103,7 +2098,7 @@ fn test_bitlist_bitlist_3_lengthy_4() {
 
 #[test]
 fn test_bitlist_bitlist_3_max_0() {
-    let mut value =
+    let value =
         <Bitlist<3> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([15]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -2114,7 +2109,7 @@ fn test_bitlist_bitlist_3_max_0() {
     let recovered_value: Bitlist<3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x251d8bd955c85219bb8f6de682810b4aafe3e0c3d3c624020fb39f81dbb85910");
     assert_eq!(root, expected_root);
@@ -2122,7 +2117,7 @@ fn test_bitlist_bitlist_3_max_0() {
 
 #[test]
 fn test_bitlist_bitlist_3_max_1() {
-    let mut value =
+    let value =
         <Bitlist<3> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([15]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -2133,7 +2128,7 @@ fn test_bitlist_bitlist_3_max_1() {
     let recovered_value: Bitlist<3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x251d8bd955c85219bb8f6de682810b4aafe3e0c3d3c624020fb39f81dbb85910");
     assert_eq!(root, expected_root);
@@ -2141,7 +2136,7 @@ fn test_bitlist_bitlist_3_max_1() {
 
 #[test]
 fn test_bitlist_bitlist_3_max_2() {
-    let mut value =
+    let value =
         <Bitlist<3> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([3]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -2152,7 +2147,7 @@ fn test_bitlist_bitlist_3_max_2() {
     let recovered_value: Bitlist<3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x56d8a66fbae0300efba7ec2c531973aaae22e7a2ed6ded081b5b32d07a32780a");
     assert_eq!(root, expected_root);
@@ -2160,7 +2155,7 @@ fn test_bitlist_bitlist_3_max_2() {
 
 #[test]
 fn test_bitlist_bitlist_3_max_3() {
-    let mut value =
+    let value =
         <Bitlist<3> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([3]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -2171,7 +2166,7 @@ fn test_bitlist_bitlist_3_max_3() {
     let recovered_value: Bitlist<3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x56d8a66fbae0300efba7ec2c531973aaae22e7a2ed6ded081b5b32d07a32780a");
     assert_eq!(root, expected_root);
@@ -2179,7 +2174,7 @@ fn test_bitlist_bitlist_3_max_3() {
 
 #[test]
 fn test_bitlist_bitlist_3_max_4() {
-    let mut value =
+    let value =
         <Bitlist<3> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([7]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -2190,7 +2185,7 @@ fn test_bitlist_bitlist_3_max_4() {
     let recovered_value: Bitlist<3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xc397e31994d6b872c69af43765ab16a1cef673be726a820dacd2637bea2f5fbb");
     assert_eq!(root, expected_root);
@@ -2198,7 +2193,7 @@ fn test_bitlist_bitlist_3_max_4() {
 
 #[test]
 fn test_bitlist_bitlist_3_nil_0() {
-    let mut value =
+    let value =
         <Bitlist<3> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -2209,7 +2204,7 @@ fn test_bitlist_bitlist_3_nil_0() {
     let recovered_value: Bitlist<3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -2217,7 +2212,7 @@ fn test_bitlist_bitlist_3_nil_0() {
 
 #[test]
 fn test_bitlist_bitlist_3_nil_1() {
-    let mut value =
+    let value =
         <Bitlist<3> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -2228,7 +2223,7 @@ fn test_bitlist_bitlist_3_nil_1() {
     let recovered_value: Bitlist<3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -2236,7 +2231,7 @@ fn test_bitlist_bitlist_3_nil_1() {
 
 #[test]
 fn test_bitlist_bitlist_3_nil_2() {
-    let mut value =
+    let value =
         <Bitlist<3> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -2247,7 +2242,7 @@ fn test_bitlist_bitlist_3_nil_2() {
     let recovered_value: Bitlist<3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -2255,7 +2250,7 @@ fn test_bitlist_bitlist_3_nil_2() {
 
 #[test]
 fn test_bitlist_bitlist_3_nil_3() {
-    let mut value =
+    let value =
         <Bitlist<3> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -2266,7 +2261,7 @@ fn test_bitlist_bitlist_3_nil_3() {
     let recovered_value: Bitlist<3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -2274,7 +2269,7 @@ fn test_bitlist_bitlist_3_nil_3() {
 
 #[test]
 fn test_bitlist_bitlist_3_nil_4() {
-    let mut value =
+    let value =
         <Bitlist<3> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -2285,7 +2280,7 @@ fn test_bitlist_bitlist_3_nil_4() {
     let recovered_value: Bitlist<3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -2293,7 +2288,7 @@ fn test_bitlist_bitlist_3_nil_4() {
 
 #[test]
 fn test_bitlist_bitlist_3_random_0() {
-    let mut value =
+    let value =
         <Bitlist<3> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([4]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -2304,7 +2299,7 @@ fn test_bitlist_bitlist_3_random_0() {
     let recovered_value: Bitlist<3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x1205f4789155711e2542dba1a64d226626fe3eb43baa854752d0b59077e010fc");
     assert_eq!(root, expected_root);
@@ -2312,7 +2307,7 @@ fn test_bitlist_bitlist_3_random_0() {
 
 #[test]
 fn test_bitlist_bitlist_3_random_1() {
-    let mut value =
+    let value =
         <Bitlist<3> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -2323,7 +2318,7 @@ fn test_bitlist_bitlist_3_random_1() {
     let recovered_value: Bitlist<3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -2331,7 +2326,7 @@ fn test_bitlist_bitlist_3_random_1() {
 
 #[test]
 fn test_bitlist_bitlist_3_random_2() {
-    let mut value =
+    let value =
         <Bitlist<3> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([5]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -2342,7 +2337,7 @@ fn test_bitlist_bitlist_3_random_2() {
     let recovered_value: Bitlist<3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xff55c97976a840b4ced964ed49e3794594ba3f675238b5fd25d282b60f70a194");
     assert_eq!(root, expected_root);
@@ -2350,7 +2345,7 @@ fn test_bitlist_bitlist_3_random_2() {
 
 #[test]
 fn test_bitlist_bitlist_3_random_3() {
-    let mut value =
+    let value =
         <Bitlist<3> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -2361,7 +2356,7 @@ fn test_bitlist_bitlist_3_random_3() {
     let recovered_value: Bitlist<3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -2369,7 +2364,7 @@ fn test_bitlist_bitlist_3_random_3() {
 
 #[test]
 fn test_bitlist_bitlist_3_random_4() {
-    let mut value =
+    let value =
         <Bitlist<3> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([4]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -2380,7 +2375,7 @@ fn test_bitlist_bitlist_3_random_4() {
     let recovered_value: Bitlist<3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x1205f4789155711e2542dba1a64d226626fe3eb43baa854752d0b59077e010fc");
     assert_eq!(root, expected_root);
@@ -2388,7 +2383,7 @@ fn test_bitlist_bitlist_3_random_4() {
 
 #[test]
 fn test_bitlist_bitlist_3_zero_0() {
-    let mut value =
+    let value =
         <Bitlist<3> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -2399,7 +2394,7 @@ fn test_bitlist_bitlist_3_zero_0() {
     let recovered_value: Bitlist<3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -2407,7 +2402,7 @@ fn test_bitlist_bitlist_3_zero_0() {
 
 #[test]
 fn test_bitlist_bitlist_3_zero_1() {
-    let mut value =
+    let value =
         <Bitlist<3> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([2]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -2418,7 +2413,7 @@ fn test_bitlist_bitlist_3_zero_1() {
     let recovered_value: Bitlist<3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xcb592844121d926f1ca3ad4e1d6fb9d8e260ed6e3216361f7732e975a0e8bbf6");
     assert_eq!(root, expected_root);
@@ -2426,7 +2421,7 @@ fn test_bitlist_bitlist_3_zero_1() {
 
 #[test]
 fn test_bitlist_bitlist_3_zero_2() {
-    let mut value =
+    let value =
         <Bitlist<3> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -2437,7 +2432,7 @@ fn test_bitlist_bitlist_3_zero_2() {
     let recovered_value: Bitlist<3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -2445,7 +2440,7 @@ fn test_bitlist_bitlist_3_zero_2() {
 
 #[test]
 fn test_bitlist_bitlist_3_zero_3() {
-    let mut value =
+    let value =
         <Bitlist<3> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([8]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -2456,7 +2451,7 @@ fn test_bitlist_bitlist_3_zero_3() {
     let recovered_value: Bitlist<3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xd86ae2ca925345bf2412bde450ac175742d979c1ea7b961bd1efe10beb9500cf");
     assert_eq!(root, expected_root);
@@ -2464,7 +2459,7 @@ fn test_bitlist_bitlist_3_zero_3() {
 
 #[test]
 fn test_bitlist_bitlist_3_zero_4() {
-    let mut value =
+    let value =
         <Bitlist<3> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -2475,7 +2470,7 @@ fn test_bitlist_bitlist_3_zero_4() {
     let recovered_value: Bitlist<3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -2493,7 +2488,7 @@ fn test_bitlist_bitlist_4_but_5() {
 
 #[test]
 fn test_bitlist_bitlist_4_lengthy_0() {
-    let mut value =
+    let value =
         <Bitlist<4> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([27]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -2504,7 +2499,7 @@ fn test_bitlist_bitlist_4_lengthy_0() {
     let recovered_value: Bitlist<4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x9d2816f451512382c000156fad1578555537321084d091d3c7b228aa705c36aa");
     assert_eq!(root, expected_root);
@@ -2512,7 +2507,7 @@ fn test_bitlist_bitlist_4_lengthy_0() {
 
 #[test]
 fn test_bitlist_bitlist_4_lengthy_1() {
-    let mut value =
+    let value =
         <Bitlist<4> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([21]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -2523,7 +2518,7 @@ fn test_bitlist_bitlist_4_lengthy_1() {
     let recovered_value: Bitlist<4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xe90722eb4d2a891700f1f3aa2e95661e707b19e60e147a96f8cf089e8cbc4bec");
     assert_eq!(root, expected_root);
@@ -2531,7 +2526,7 @@ fn test_bitlist_bitlist_4_lengthy_1() {
 
 #[test]
 fn test_bitlist_bitlist_4_lengthy_2() {
-    let mut value =
+    let value =
         <Bitlist<4> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([23]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -2542,7 +2537,7 @@ fn test_bitlist_bitlist_4_lengthy_2() {
     let recovered_value: Bitlist<4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x374bd7c88680671ad4be6e1b576db80646d992d893a5eeb1d1d0f403c3331b32");
     assert_eq!(root, expected_root);
@@ -2550,7 +2545,7 @@ fn test_bitlist_bitlist_4_lengthy_2() {
 
 #[test]
 fn test_bitlist_bitlist_4_lengthy_3() {
-    let mut value =
+    let value =
         <Bitlist<4> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([17]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -2561,7 +2556,7 @@ fn test_bitlist_bitlist_4_lengthy_3() {
     let recovered_value: Bitlist<4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf9c5ada16029ed1580188989686f19e749c006b2eac37d3ef087b824b31ba997");
     assert_eq!(root, expected_root);
@@ -2569,7 +2564,7 @@ fn test_bitlist_bitlist_4_lengthy_3() {
 
 #[test]
 fn test_bitlist_bitlist_4_lengthy_4() {
-    let mut value =
+    let value =
         <Bitlist<4> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([22]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -2580,7 +2575,7 @@ fn test_bitlist_bitlist_4_lengthy_4() {
     let recovered_value: Bitlist<4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x894e8a2ce460c6c6ba12d467634e6c34ce2a1b58d0c6dfe3d98b532898c58611");
     assert_eq!(root, expected_root);
@@ -2588,7 +2583,7 @@ fn test_bitlist_bitlist_4_lengthy_4() {
 
 #[test]
 fn test_bitlist_bitlist_4_max_0() {
-    let mut value =
+    let value =
         <Bitlist<4> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([15]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -2599,7 +2594,7 @@ fn test_bitlist_bitlist_4_max_0() {
     let recovered_value: Bitlist<4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x251d8bd955c85219bb8f6de682810b4aafe3e0c3d3c624020fb39f81dbb85910");
     assert_eq!(root, expected_root);
@@ -2607,7 +2602,7 @@ fn test_bitlist_bitlist_4_max_0() {
 
 #[test]
 fn test_bitlist_bitlist_4_max_1() {
-    let mut value =
+    let value =
         <Bitlist<4> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([3]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -2618,7 +2613,7 @@ fn test_bitlist_bitlist_4_max_1() {
     let recovered_value: Bitlist<4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x56d8a66fbae0300efba7ec2c531973aaae22e7a2ed6ded081b5b32d07a32780a");
     assert_eq!(root, expected_root);
@@ -2626,7 +2621,7 @@ fn test_bitlist_bitlist_4_max_1() {
 
 #[test]
 fn test_bitlist_bitlist_4_max_2() {
-    let mut value =
+    let value =
         <Bitlist<4> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -2637,7 +2632,7 @@ fn test_bitlist_bitlist_4_max_2() {
     let recovered_value: Bitlist<4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -2645,7 +2640,7 @@ fn test_bitlist_bitlist_4_max_2() {
 
 #[test]
 fn test_bitlist_bitlist_4_max_3() {
-    let mut value =
+    let value =
         <Bitlist<4> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([31]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -2656,7 +2651,7 @@ fn test_bitlist_bitlist_4_max_3() {
     let recovered_value: Bitlist<4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x4b07c3799db025f3aa92ced1e8545367a2b6e44960f479d3f9d62b61812892d5");
     assert_eq!(root, expected_root);
@@ -2664,7 +2659,7 @@ fn test_bitlist_bitlist_4_max_3() {
 
 #[test]
 fn test_bitlist_bitlist_4_max_4() {
-    let mut value =
+    let value =
         <Bitlist<4> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([7]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -2675,7 +2670,7 @@ fn test_bitlist_bitlist_4_max_4() {
     let recovered_value: Bitlist<4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xc397e31994d6b872c69af43765ab16a1cef673be726a820dacd2637bea2f5fbb");
     assert_eq!(root, expected_root);
@@ -2683,7 +2678,7 @@ fn test_bitlist_bitlist_4_max_4() {
 
 #[test]
 fn test_bitlist_bitlist_4_nil_0() {
-    let mut value =
+    let value =
         <Bitlist<4> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -2694,7 +2689,7 @@ fn test_bitlist_bitlist_4_nil_0() {
     let recovered_value: Bitlist<4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -2702,7 +2697,7 @@ fn test_bitlist_bitlist_4_nil_0() {
 
 #[test]
 fn test_bitlist_bitlist_4_nil_1() {
-    let mut value =
+    let value =
         <Bitlist<4> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -2713,7 +2708,7 @@ fn test_bitlist_bitlist_4_nil_1() {
     let recovered_value: Bitlist<4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -2721,7 +2716,7 @@ fn test_bitlist_bitlist_4_nil_1() {
 
 #[test]
 fn test_bitlist_bitlist_4_nil_2() {
-    let mut value =
+    let value =
         <Bitlist<4> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -2732,7 +2727,7 @@ fn test_bitlist_bitlist_4_nil_2() {
     let recovered_value: Bitlist<4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -2740,7 +2735,7 @@ fn test_bitlist_bitlist_4_nil_2() {
 
 #[test]
 fn test_bitlist_bitlist_4_nil_3() {
-    let mut value =
+    let value =
         <Bitlist<4> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -2751,7 +2746,7 @@ fn test_bitlist_bitlist_4_nil_3() {
     let recovered_value: Bitlist<4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -2759,7 +2754,7 @@ fn test_bitlist_bitlist_4_nil_3() {
 
 #[test]
 fn test_bitlist_bitlist_4_nil_4() {
-    let mut value =
+    let value =
         <Bitlist<4> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -2770,7 +2765,7 @@ fn test_bitlist_bitlist_4_nil_4() {
     let recovered_value: Bitlist<4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -2778,7 +2773,7 @@ fn test_bitlist_bitlist_4_nil_4() {
 
 #[test]
 fn test_bitlist_bitlist_4_random_0() {
-    let mut value =
+    let value =
         <Bitlist<4> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([13]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -2789,7 +2784,7 @@ fn test_bitlist_bitlist_4_random_0() {
     let recovered_value: Bitlist<4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xcf8ca64c265b9b6234fb7573a200745204fd04fecf680f1157f27367ee8f4aa2");
     assert_eq!(root, expected_root);
@@ -2797,7 +2792,7 @@ fn test_bitlist_bitlist_4_random_0() {
 
 #[test]
 fn test_bitlist_bitlist_4_random_1() {
-    let mut value =
+    let value =
         <Bitlist<4> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([17]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -2808,7 +2803,7 @@ fn test_bitlist_bitlist_4_random_1() {
     let recovered_value: Bitlist<4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf9c5ada16029ed1580188989686f19e749c006b2eac37d3ef087b824b31ba997");
     assert_eq!(root, expected_root);
@@ -2816,7 +2811,7 @@ fn test_bitlist_bitlist_4_random_1() {
 
 #[test]
 fn test_bitlist_bitlist_4_random_2() {
-    let mut value =
+    let value =
         <Bitlist<4> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([3]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -2827,7 +2822,7 @@ fn test_bitlist_bitlist_4_random_2() {
     let recovered_value: Bitlist<4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x56d8a66fbae0300efba7ec2c531973aaae22e7a2ed6ded081b5b32d07a32780a");
     assert_eq!(root, expected_root);
@@ -2835,7 +2830,7 @@ fn test_bitlist_bitlist_4_random_2() {
 
 #[test]
 fn test_bitlist_bitlist_4_random_3() {
-    let mut value =
+    let value =
         <Bitlist<4> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([2]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -2846,7 +2841,7 @@ fn test_bitlist_bitlist_4_random_3() {
     let recovered_value: Bitlist<4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xcb592844121d926f1ca3ad4e1d6fb9d8e260ed6e3216361f7732e975a0e8bbf6");
     assert_eq!(root, expected_root);
@@ -2854,7 +2849,7 @@ fn test_bitlist_bitlist_4_random_3() {
 
 #[test]
 fn test_bitlist_bitlist_4_random_4() {
-    let mut value =
+    let value =
         <Bitlist<4> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([4]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -2865,7 +2860,7 @@ fn test_bitlist_bitlist_4_random_4() {
     let recovered_value: Bitlist<4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x1205f4789155711e2542dba1a64d226626fe3eb43baa854752d0b59077e010fc");
     assert_eq!(root, expected_root);
@@ -2873,7 +2868,7 @@ fn test_bitlist_bitlist_4_random_4() {
 
 #[test]
 fn test_bitlist_bitlist_4_zero_0() {
-    let mut value =
+    let value =
         <Bitlist<4> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([16]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -2884,7 +2879,7 @@ fn test_bitlist_bitlist_4_zero_0() {
     let recovered_value: Bitlist<4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xd647eb2598d33d7216256356596d29cecd31c1ba7a7ff25ccb5be4a453410b9d");
     assert_eq!(root, expected_root);
@@ -2892,7 +2887,7 @@ fn test_bitlist_bitlist_4_zero_0() {
 
 #[test]
 fn test_bitlist_bitlist_4_zero_1() {
-    let mut value =
+    let value =
         <Bitlist<4> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([2]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -2903,7 +2898,7 @@ fn test_bitlist_bitlist_4_zero_1() {
     let recovered_value: Bitlist<4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xcb592844121d926f1ca3ad4e1d6fb9d8e260ed6e3216361f7732e975a0e8bbf6");
     assert_eq!(root, expected_root);
@@ -2911,7 +2906,7 @@ fn test_bitlist_bitlist_4_zero_1() {
 
 #[test]
 fn test_bitlist_bitlist_4_zero_2() {
-    let mut value =
+    let value =
         <Bitlist<4> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -2922,7 +2917,7 @@ fn test_bitlist_bitlist_4_zero_2() {
     let recovered_value: Bitlist<4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -2930,7 +2925,7 @@ fn test_bitlist_bitlist_4_zero_2() {
 
 #[test]
 fn test_bitlist_bitlist_4_zero_3() {
-    let mut value =
+    let value =
         <Bitlist<4> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([4]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -2941,7 +2936,7 @@ fn test_bitlist_bitlist_4_zero_3() {
     let recovered_value: Bitlist<4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x1205f4789155711e2542dba1a64d226626fe3eb43baa854752d0b59077e010fc");
     assert_eq!(root, expected_root);
@@ -2949,7 +2944,7 @@ fn test_bitlist_bitlist_4_zero_3() {
 
 #[test]
 fn test_bitlist_bitlist_4_zero_4() {
-    let mut value =
+    let value =
         <Bitlist<4> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([16]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -2960,7 +2955,7 @@ fn test_bitlist_bitlist_4_zero_4() {
     let recovered_value: Bitlist<4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xd647eb2598d33d7216256356596d29cecd31c1ba7a7ff25ccb5be4a453410b9d");
     assert_eq!(root, expected_root);
@@ -2978,7 +2973,7 @@ fn test_bitlist_bitlist_512_but_513() {
 
 #[test]
 fn test_bitlist_bitlist_512_lengthy_0() {
-    let mut value = <Bitlist<512> as TryFrom<&[u8]>>::try_from(
+    let value = <Bitlist<512> as TryFrom<&[u8]>>::try_from(
         Vec::<u8>::from_iter([
             0, 41, 128, 156, 65, 44, 152, 213, 145, 249, 231, 3, 54, 176, 161, 20, 245, 248, 201,
             32, 174, 50, 123, 243, 222, 100, 4, 130, 7, 198, 31, 26, 234, 146, 83, 208, 194, 122,
@@ -2997,7 +2992,7 @@ fn test_bitlist_bitlist_512_lengthy_0() {
     let recovered_value: Bitlist<512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xbc152fc83f6fefea40b3b3fdf626dc1af7eaea74e6bce7aba12a6602679004e1");
     assert_eq!(root, expected_root);
@@ -3005,7 +3000,7 @@ fn test_bitlist_bitlist_512_lengthy_0() {
 
 #[test]
 fn test_bitlist_bitlist_512_lengthy_1() {
-    let mut value = <Bitlist<512> as TryFrom<&[u8]>>::try_from(
+    let value = <Bitlist<512> as TryFrom<&[u8]>>::try_from(
         Vec::<u8>::from_iter([
             94, 184, 1, 99, 49, 235, 82, 205, 193, 182, 48, 217, 245, 230, 218, 190, 200, 144, 130,
             53, 80, 167, 110, 209, 85, 249, 213, 138, 164, 151, 175, 125, 200, 249, 196, 207, 214,
@@ -3024,7 +3019,7 @@ fn test_bitlist_bitlist_512_lengthy_1() {
     let recovered_value: Bitlist<512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x2b28c2217c3f1f99e0c5ad46c77be392323ae7c6e68612e6b1701e762a0285e7");
     assert_eq!(root, expected_root);
@@ -3032,7 +3027,7 @@ fn test_bitlist_bitlist_512_lengthy_1() {
 
 #[test]
 fn test_bitlist_bitlist_512_lengthy_2() {
-    let mut value = <Bitlist<512> as TryFrom<&[u8]>>::try_from(
+    let value = <Bitlist<512> as TryFrom<&[u8]>>::try_from(
         Vec::<u8>::from_iter([
             161, 54, 224, 29, 250, 19, 154, 61, 234, 110, 180, 240, 239, 156, 21, 64, 107, 106, 17,
             233, 80, 37, 181, 67, 39, 44, 105, 232, 196, 133, 9, 158, 189, 240, 53, 62, 87, 32,
@@ -3051,7 +3046,7 @@ fn test_bitlist_bitlist_512_lengthy_2() {
     let recovered_value: Bitlist<512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x04d0ff41239e5365cafa09c58dedb823eb13cb4912afea9fc26a658b955a4594");
     assert_eq!(root, expected_root);
@@ -3059,7 +3054,7 @@ fn test_bitlist_bitlist_512_lengthy_2() {
 
 #[test]
 fn test_bitlist_bitlist_512_lengthy_3() {
-    let mut value = <Bitlist<512> as TryFrom<&[u8]>>::try_from(
+    let value = <Bitlist<512> as TryFrom<&[u8]>>::try_from(
         Vec::<u8>::from_iter([
             7, 77, 193, 97, 6, 198, 213, 2, 67, 206, 135, 31, 250, 188, 197, 117, 43, 158, 239,
             119, 214, 235, 178, 157, 44, 138, 110, 35, 81, 248, 201, 84, 190, 88, 184, 122, 203,
@@ -3078,7 +3073,7 @@ fn test_bitlist_bitlist_512_lengthy_3() {
     let recovered_value: Bitlist<512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x57d984dd8dc742665160586d43e684d59f48ea2fbf7ff6fc6742cdcf050bea09");
     assert_eq!(root, expected_root);
@@ -3086,7 +3081,7 @@ fn test_bitlist_bitlist_512_lengthy_3() {
 
 #[test]
 fn test_bitlist_bitlist_512_lengthy_4() {
-    let mut value = <Bitlist<512> as TryFrom<&[u8]>>::try_from(
+    let value = <Bitlist<512> as TryFrom<&[u8]>>::try_from(
         Vec::<u8>::from_iter([
             18, 50, 181, 231, 116, 52, 232, 102, 4, 191, 32, 1, 249, 166, 102, 194, 183, 79, 119,
             8, 192, 206, 36, 45, 150, 71, 35, 141, 185, 152, 251, 167, 194, 89, 90, 22, 11, 201,
@@ -3105,7 +3100,7 @@ fn test_bitlist_bitlist_512_lengthy_4() {
     let recovered_value: Bitlist<512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x28933deb812002abaf34c610f6b2f77cb8acbc617d5a8f8a320ca4813c29fea2");
     assert_eq!(root, expected_root);
@@ -3113,7 +3108,7 @@ fn test_bitlist_bitlist_512_lengthy_4() {
 
 #[test]
 fn test_bitlist_bitlist_512_max_0() {
-    let mut value = <Bitlist<512> as TryFrom<&[u8]>>::try_from(
+    let value = <Bitlist<512> as TryFrom<&[u8]>>::try_from(
         Vec::<u8>::from_iter([
             255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
             255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
@@ -3131,7 +3126,7 @@ fn test_bitlist_bitlist_512_max_0() {
     let recovered_value: Bitlist<512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xbbf3224946b87b12d7c3c24d4887a1a1bdb6afd356e3fb40bfa7a42cd0a7d478");
     assert_eq!(root, expected_root);
@@ -3139,7 +3134,7 @@ fn test_bitlist_bitlist_512_max_0() {
 
 #[test]
 fn test_bitlist_bitlist_512_max_1() {
-    let mut value = <Bitlist<512> as TryFrom<&[u8]>>::try_from(
+    let value = <Bitlist<512> as TryFrom<&[u8]>>::try_from(
         Vec::<u8>::from_iter([
             255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
             255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
@@ -3157,7 +3152,7 @@ fn test_bitlist_bitlist_512_max_1() {
     let recovered_value: Bitlist<512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xca6250f3556974d64650a327c0551859f706d9778399caff8a6be920d88fb39f");
     assert_eq!(root, expected_root);
@@ -3165,7 +3160,7 @@ fn test_bitlist_bitlist_512_max_1() {
 
 #[test]
 fn test_bitlist_bitlist_512_max_2() {
-    let mut value = <Bitlist<512> as TryFrom<&[u8]>>::try_from(
+    let value = <Bitlist<512> as TryFrom<&[u8]>>::try_from(
         Vec::<u8>::from_iter([
             255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
             255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
@@ -3183,7 +3178,7 @@ fn test_bitlist_bitlist_512_max_2() {
     let recovered_value: Bitlist<512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x08e61443f630601ca65f47622a47ef029baad7a757f3f1d10de0098c9add4589");
     assert_eq!(root, expected_root);
@@ -3191,7 +3186,7 @@ fn test_bitlist_bitlist_512_max_2() {
 
 #[test]
 fn test_bitlist_bitlist_512_max_3() {
-    let mut value = <Bitlist<512> as TryFrom<&[u8]>>::try_from(
+    let value = <Bitlist<512> as TryFrom<&[u8]>>::try_from(
         Vec::<u8>::from_iter([255, 255, 255, 255, 255, 255, 7]).as_ref(),
     )
     .unwrap();
@@ -3204,7 +3199,7 @@ fn test_bitlist_bitlist_512_max_3() {
     let recovered_value: Bitlist<512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x8cbf50b584a296a316a71c486b4d4e1fd94edae9bf75f1aff71b8f609dc8352c");
     assert_eq!(root, expected_root);
@@ -3212,7 +3207,7 @@ fn test_bitlist_bitlist_512_max_3() {
 
 #[test]
 fn test_bitlist_bitlist_512_max_4() {
-    let mut value = <Bitlist<512> as TryFrom<&[u8]>>::try_from(
+    let value = <Bitlist<512> as TryFrom<&[u8]>>::try_from(
         Vec::<u8>::from_iter([
             255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
             255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 31,
@@ -3229,7 +3224,7 @@ fn test_bitlist_bitlist_512_max_4() {
     let recovered_value: Bitlist<512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x1bb7ab569c8b46d1e40884241195c1369ea760bf957583d3a78a4315c0e2f495");
     assert_eq!(root, expected_root);
@@ -3237,7 +3232,7 @@ fn test_bitlist_bitlist_512_max_4() {
 
 #[test]
 fn test_bitlist_bitlist_512_nil_0() {
-    let mut value =
+    let value =
         <Bitlist<512> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -3248,7 +3243,7 @@ fn test_bitlist_bitlist_512_nil_0() {
     let recovered_value: Bitlist<512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x7a0501f5957bdf9cb3a8ff4966f02265f968658b7a9c62642cba1165e86642f5");
     assert_eq!(root, expected_root);
@@ -3256,7 +3251,7 @@ fn test_bitlist_bitlist_512_nil_0() {
 
 #[test]
 fn test_bitlist_bitlist_512_nil_1() {
-    let mut value =
+    let value =
         <Bitlist<512> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -3267,7 +3262,7 @@ fn test_bitlist_bitlist_512_nil_1() {
     let recovered_value: Bitlist<512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x7a0501f5957bdf9cb3a8ff4966f02265f968658b7a9c62642cba1165e86642f5");
     assert_eq!(root, expected_root);
@@ -3275,7 +3270,7 @@ fn test_bitlist_bitlist_512_nil_1() {
 
 #[test]
 fn test_bitlist_bitlist_512_nil_2() {
-    let mut value =
+    let value =
         <Bitlist<512> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -3286,7 +3281,7 @@ fn test_bitlist_bitlist_512_nil_2() {
     let recovered_value: Bitlist<512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x7a0501f5957bdf9cb3a8ff4966f02265f968658b7a9c62642cba1165e86642f5");
     assert_eq!(root, expected_root);
@@ -3294,7 +3289,7 @@ fn test_bitlist_bitlist_512_nil_2() {
 
 #[test]
 fn test_bitlist_bitlist_512_nil_3() {
-    let mut value =
+    let value =
         <Bitlist<512> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -3305,7 +3300,7 @@ fn test_bitlist_bitlist_512_nil_3() {
     let recovered_value: Bitlist<512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x7a0501f5957bdf9cb3a8ff4966f02265f968658b7a9c62642cba1165e86642f5");
     assert_eq!(root, expected_root);
@@ -3313,7 +3308,7 @@ fn test_bitlist_bitlist_512_nil_3() {
 
 #[test]
 fn test_bitlist_bitlist_512_nil_4() {
-    let mut value =
+    let value =
         <Bitlist<512> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -3324,7 +3319,7 @@ fn test_bitlist_bitlist_512_nil_4() {
     let recovered_value: Bitlist<512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x7a0501f5957bdf9cb3a8ff4966f02265f968658b7a9c62642cba1165e86642f5");
     assert_eq!(root, expected_root);
@@ -3332,7 +3327,7 @@ fn test_bitlist_bitlist_512_nil_4() {
 
 #[test]
 fn test_bitlist_bitlist_512_random_0() {
-    let mut value = <Bitlist<512> as TryFrom<&[u8]>>::try_from(
+    let value = <Bitlist<512> as TryFrom<&[u8]>>::try_from(
         Vec::<u8>::from_iter([
             159, 193, 65, 83, 153, 201, 138, 172, 149, 135, 213, 123, 40, 144, 145, 240, 5, 101,
             30, 231, 103, 140, 116, 89, 117, 244, 128, 217, 64, 252, 136, 195, 115, 226, 161, 234,
@@ -3350,7 +3345,7 @@ fn test_bitlist_bitlist_512_random_0() {
     let recovered_value: Bitlist<512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xd01782fa00046d31ecef1828d806bc82a0635ba68a829abaea5bc5e83cfc3b39");
     assert_eq!(root, expected_root);
@@ -3358,7 +3353,7 @@ fn test_bitlist_bitlist_512_random_0() {
 
 #[test]
 fn test_bitlist_bitlist_512_random_1() {
-    let mut value = <Bitlist<512> as TryFrom<&[u8]>>::try_from(
+    let value = <Bitlist<512> as TryFrom<&[u8]>>::try_from(
         Vec::<u8>::from_iter([138, 214, 36, 127, 4, 4]).as_ref(),
     )
     .unwrap();
@@ -3371,7 +3366,7 @@ fn test_bitlist_bitlist_512_random_1() {
     let recovered_value: Bitlist<512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x4979bcefe3ded00d52ea1342595d1390e372a93c4acf10ed2c3c1fc604d1a92e");
     assert_eq!(root, expected_root);
@@ -3379,7 +3374,7 @@ fn test_bitlist_bitlist_512_random_1() {
 
 #[test]
 fn test_bitlist_bitlist_512_random_2() {
-    let mut value = <Bitlist<512> as TryFrom<&[u8]>>::try_from(
+    let value = <Bitlist<512> as TryFrom<&[u8]>>::try_from(
         Vec::<u8>::from_iter([
             55, 212, 241, 100, 234, 188, 0, 34, 27, 192, 190, 127, 91, 209, 229, 142, 167, 28, 205,
             84, 238, 210, 242, 138, 164, 125, 156, 167, 143, 125, 166, 47, 243, 117, 126, 131, 242,
@@ -3397,7 +3392,7 @@ fn test_bitlist_bitlist_512_random_2() {
     let recovered_value: Bitlist<512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0885e8d339f7016801875ef256eb180be417810e6151703137877f68926952f5");
     assert_eq!(root, expected_root);
@@ -3405,7 +3400,7 @@ fn test_bitlist_bitlist_512_random_2() {
 
 #[test]
 fn test_bitlist_bitlist_512_random_3() {
-    let mut value = <Bitlist<512> as TryFrom<&[u8]>>::try_from(
+    let value = <Bitlist<512> as TryFrom<&[u8]>>::try_from(
         Vec::<u8>::from_iter([
             114, 184, 230, 175, 17, 28, 190, 227, 166, 99, 92, 23, 192, 50, 85, 247, 116, 227, 60,
             162, 196, 86, 135, 217, 176, 85, 95, 52, 220, 1, 21, 183, 204, 52,
@@ -3422,7 +3417,7 @@ fn test_bitlist_bitlist_512_random_3() {
     let recovered_value: Bitlist<512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0c24b4aa44483bc91415618c8d23fa1ec87cbbf57dd1747ac001513f3ddeea8c");
     assert_eq!(root, expected_root);
@@ -3430,7 +3425,7 @@ fn test_bitlist_bitlist_512_random_3() {
 
 #[test]
 fn test_bitlist_bitlist_512_random_4() {
-    let mut value = <Bitlist<512> as TryFrom<&[u8]>>::try_from(
+    let value = <Bitlist<512> as TryFrom<&[u8]>>::try_from(
         Vec::<u8>::from_iter([
             96, 46, 1, 71, 234, 203, 14, 250, 120, 192, 34, 73, 169, 192, 182, 165, 161, 213, 114,
             128, 250, 72, 183, 182, 164, 2, 138, 211, 54, 233, 137, 237, 21, 53, 242, 229, 217, 36,
@@ -3448,7 +3443,7 @@ fn test_bitlist_bitlist_512_random_4() {
     let recovered_value: Bitlist<512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x813ccb937403bbd02d4ce9cd7e101c3bf3214ed4a1d8c11199288fbcdca45860");
     assert_eq!(root, expected_root);
@@ -3456,7 +3451,7 @@ fn test_bitlist_bitlist_512_random_4() {
 
 #[test]
 fn test_bitlist_bitlist_512_zero_0() {
-    let mut value = <Bitlist<512> as TryFrom<&[u8]>>::try_from(
+    let value = <Bitlist<512> as TryFrom<&[u8]>>::try_from(
         Vec::<u8>::from_iter([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 16])
             .as_ref(),
     )
@@ -3470,7 +3465,7 @@ fn test_bitlist_bitlist_512_zero_0() {
     let recovered_value: Bitlist<512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xb9622f5ac7a4f2982e31494019e6fc83a8510ba1313084df18fe74cfd63fff28");
     assert_eq!(root, expected_root);
@@ -3478,7 +3473,7 @@ fn test_bitlist_bitlist_512_zero_0() {
 
 #[test]
 fn test_bitlist_bitlist_512_zero_1() {
-    let mut value = <Bitlist<512> as TryFrom<&[u8]>>::try_from(
+    let value = <Bitlist<512> as TryFrom<&[u8]>>::try_from(
         Vec::<u8>::from_iter([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -3496,7 +3491,7 @@ fn test_bitlist_bitlist_512_zero_1() {
     let recovered_value: Bitlist<512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x4d8dddd9769fcea91305afd9f96b9b187ad7dbd994a67cea4eeb7e2c0348c292");
     assert_eq!(root, expected_root);
@@ -3504,7 +3499,7 @@ fn test_bitlist_bitlist_512_zero_1() {
 
 #[test]
 fn test_bitlist_bitlist_512_zero_2() {
-    let mut value = <Bitlist<512> as TryFrom<&[u8]>>::try_from(
+    let value = <Bitlist<512> as TryFrom<&[u8]>>::try_from(
         Vec::<u8>::from_iter([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 1,
@@ -3521,7 +3516,7 @@ fn test_bitlist_bitlist_512_zero_2() {
     let recovered_value: Bitlist<512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0f4ea9e6bc6fce537e76838bafa08072aec839c4acc1d3a8c62bb4a253a0a451");
     assert_eq!(root, expected_root);
@@ -3529,7 +3524,7 @@ fn test_bitlist_bitlist_512_zero_2() {
 
 #[test]
 fn test_bitlist_bitlist_512_zero_3() {
-    let mut value = <Bitlist<512> as TryFrom<&[u8]>>::try_from(
+    let value = <Bitlist<512> as TryFrom<&[u8]>>::try_from(
         Vec::<u8>::from_iter([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4,
@@ -3546,7 +3541,7 @@ fn test_bitlist_bitlist_512_zero_3() {
     let recovered_value: Bitlist<512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xec7fd7a922a87b641e3c8e0f2b092b1f470050c14409fcd95985c07024a429f4");
     assert_eq!(root, expected_root);
@@ -3554,7 +3549,7 @@ fn test_bitlist_bitlist_512_zero_3() {
 
 #[test]
 fn test_bitlist_bitlist_512_zero_4() {
-    let mut value = <Bitlist<512> as TryFrom<&[u8]>>::try_from(
+    let value = <Bitlist<512> as TryFrom<&[u8]>>::try_from(
         Vec::<u8>::from_iter([0, 0, 0, 0, 0, 0, 0, 0, 64]).as_ref(),
     )
     .unwrap();
@@ -3567,7 +3562,7 @@ fn test_bitlist_bitlist_512_zero_4() {
     let recovered_value: Bitlist<512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xc3f35acbdbda16dc35969a4b0c817b2a7c9f8b037ace72cae4efb76797d8d4c4");
     assert_eq!(root, expected_root);
@@ -3575,7 +3570,7 @@ fn test_bitlist_bitlist_512_zero_4() {
 
 #[test]
 fn test_bitlist_bitlist_513_lengthy_0() {
-    let mut value = <Bitlist<513> as TryFrom<&[u8]>>::try_from(
+    let value = <Bitlist<513> as TryFrom<&[u8]>>::try_from(
         Vec::<u8>::from_iter([
             104, 108, 147, 82, 247, 10, 41, 236, 81, 255, 119, 145, 12, 63, 124, 131, 21, 211, 196,
             125, 161, 242, 222, 193, 156, 133, 68, 174, 17, 238, 8, 37, 152, 152, 73, 25, 20, 138,
@@ -3594,7 +3589,7 @@ fn test_bitlist_bitlist_513_lengthy_0() {
     let recovered_value: Bitlist<513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x77184930e328732d5413240f6114e269a9df6573d8b177f03d328eda7d3ffae2");
     assert_eq!(root, expected_root);
@@ -3602,7 +3597,7 @@ fn test_bitlist_bitlist_513_lengthy_0() {
 
 #[test]
 fn test_bitlist_bitlist_513_lengthy_1() {
-    let mut value = <Bitlist<513> as TryFrom<&[u8]>>::try_from(
+    let value = <Bitlist<513> as TryFrom<&[u8]>>::try_from(
         Vec::<u8>::from_iter([
             57, 91, 36, 187, 64, 156, 244, 32, 187, 84, 133, 47, 148, 184, 58, 241, 3, 82, 62, 202,
             39, 171, 189, 7, 100, 10, 34, 56, 58, 210, 187, 14, 160, 147, 70, 195, 165, 234, 63,
@@ -3621,7 +3616,7 @@ fn test_bitlist_bitlist_513_lengthy_1() {
     let recovered_value: Bitlist<513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x10041d4cf07da1077e84c9b5c01fa6d5f29ba8feb934ebdf7ca184a2857cdf55");
     assert_eq!(root, expected_root);
@@ -3629,7 +3624,7 @@ fn test_bitlist_bitlist_513_lengthy_1() {
 
 #[test]
 fn test_bitlist_bitlist_513_lengthy_2() {
-    let mut value = <Bitlist<513> as TryFrom<&[u8]>>::try_from(
+    let value = <Bitlist<513> as TryFrom<&[u8]>>::try_from(
         Vec::<u8>::from_iter([
             33, 218, 166, 15, 249, 225, 154, 205, 6, 215, 100, 77, 14, 16, 207, 196, 191, 216, 118,
             102, 63, 223, 211, 47, 81, 105, 148, 151, 230, 101, 199, 64, 63, 199, 177, 176, 74,
@@ -3648,7 +3643,7 @@ fn test_bitlist_bitlist_513_lengthy_2() {
     let recovered_value: Bitlist<513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xfcc1fb245d5eae1370c4cfaf51a23a68d24fc931eb75d8e3b337eadf1c94b4be");
     assert_eq!(root, expected_root);
@@ -3656,7 +3651,7 @@ fn test_bitlist_bitlist_513_lengthy_2() {
 
 #[test]
 fn test_bitlist_bitlist_513_lengthy_3() {
-    let mut value = <Bitlist<513> as TryFrom<&[u8]>>::try_from(
+    let value = <Bitlist<513> as TryFrom<&[u8]>>::try_from(
         Vec::<u8>::from_iter([
             244, 116, 125, 246, 185, 122, 37, 121, 40, 135, 61, 96, 114, 88, 163, 166, 254, 68,
             177, 16, 10, 122, 24, 95, 35, 204, 170, 225, 207, 108, 158, 179, 248, 186, 81, 253,
@@ -3675,7 +3670,7 @@ fn test_bitlist_bitlist_513_lengthy_3() {
     let recovered_value: Bitlist<513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xeb5acc36387e3d3e44187bd6c086e4409fab204daa33ad40a99226dd2c487d8e");
     assert_eq!(root, expected_root);
@@ -3683,7 +3678,7 @@ fn test_bitlist_bitlist_513_lengthy_3() {
 
 #[test]
 fn test_bitlist_bitlist_513_lengthy_4() {
-    let mut value = <Bitlist<513> as TryFrom<&[u8]>>::try_from(
+    let value = <Bitlist<513> as TryFrom<&[u8]>>::try_from(
         Vec::<u8>::from_iter([
             61, 93, 109, 239, 248, 61, 228, 130, 190, 124, 243, 93, 119, 224, 242, 90, 116, 204,
             103, 69, 123, 151, 6, 222, 218, 77, 32, 82, 17, 10, 27, 133, 187, 42, 87, 77, 193, 194,
@@ -3702,7 +3697,7 @@ fn test_bitlist_bitlist_513_lengthy_4() {
     let recovered_value: Bitlist<513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x4edc0e0f8cb3511f8e89e5a9d73fdd50270e49aa8bfa62ffe8c8e99c161e76ba");
     assert_eq!(root, expected_root);
@@ -3710,7 +3705,7 @@ fn test_bitlist_bitlist_513_lengthy_4() {
 
 #[test]
 fn test_bitlist_bitlist_513_max_0() {
-    let mut value = <Bitlist<513> as TryFrom<&[u8]>>::try_from(
+    let value = <Bitlist<513> as TryFrom<&[u8]>>::try_from(
         Vec::<u8>::from_iter([
             255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
             255, 255, 255, 255, 7,
@@ -3727,7 +3722,7 @@ fn test_bitlist_bitlist_513_max_0() {
     let recovered_value: Bitlist<513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x3116c9a3fab7c6ebf0978f8ef07aa2c27ea9c79887d773980a39b95e5c035593");
     assert_eq!(root, expected_root);
@@ -3735,7 +3730,7 @@ fn test_bitlist_bitlist_513_max_0() {
 
 #[test]
 fn test_bitlist_bitlist_513_max_1() {
-    let mut value =
+    let value =
         <Bitlist<513> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([127]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -3746,7 +3741,7 @@ fn test_bitlist_bitlist_513_max_1() {
     let recovered_value: Bitlist<513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xb00f282b126680bcbd302d657b117dc32294c4cb586f76c244932141012e6a82");
     assert_eq!(root, expected_root);
@@ -3754,9 +3749,8 @@ fn test_bitlist_bitlist_513_max_1() {
 
 #[test]
 fn test_bitlist_bitlist_513_max_2() {
-    let mut value =
-        <Bitlist<513> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([255, 1]).as_ref())
-            .unwrap();
+    let value = <Bitlist<513> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([255, 1]).as_ref())
+        .unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/bitlist/valid/bitlist_513_max_2/serialized.ssz_snappy",
@@ -3766,7 +3760,7 @@ fn test_bitlist_bitlist_513_max_2() {
     let recovered_value: Bitlist<513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x848557322ff06141bbb7ac657b15c24e6300986a5ff8ce878ef4b198c0bd51b0");
     assert_eq!(root, expected_root);
@@ -3774,7 +3768,7 @@ fn test_bitlist_bitlist_513_max_2() {
 
 #[test]
 fn test_bitlist_bitlist_513_max_3() {
-    let mut value = <Bitlist<513> as TryFrom<&[u8]>>::try_from(
+    let value = <Bitlist<513> as TryFrom<&[u8]>>::try_from(
         Vec::<u8>::from_iter([
             255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
             255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
@@ -3792,7 +3786,7 @@ fn test_bitlist_bitlist_513_max_3() {
     let recovered_value: Bitlist<513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xa575735c9960d438c8bdd59d05fedefce22f8e5b77b09efb5b4e9942b847468e");
     assert_eq!(root, expected_root);
@@ -3800,7 +3794,7 @@ fn test_bitlist_bitlist_513_max_3() {
 
 #[test]
 fn test_bitlist_bitlist_513_max_4() {
-    let mut value = <Bitlist<513> as TryFrom<&[u8]>>::try_from(
+    let value = <Bitlist<513> as TryFrom<&[u8]>>::try_from(
         Vec::<u8>::from_iter([
             255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 1,
         ])
@@ -3816,7 +3810,7 @@ fn test_bitlist_bitlist_513_max_4() {
     let recovered_value: Bitlist<513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xe05d10ac23b945573dca5263c13a7eaf50854397bf48f920175a10509bf65ecf");
     assert_eq!(root, expected_root);
@@ -3824,7 +3818,7 @@ fn test_bitlist_bitlist_513_max_4() {
 
 #[test]
 fn test_bitlist_bitlist_513_nil_0() {
-    let mut value =
+    let value =
         <Bitlist<513> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -3835,7 +3829,7 @@ fn test_bitlist_bitlist_513_nil_0() {
     let recovered_value: Bitlist<513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x28ba1834a3a7b657460ce79fa3a1d909ab8828fd557659d4d0554a9bdbc0ec30");
     assert_eq!(root, expected_root);
@@ -3843,7 +3837,7 @@ fn test_bitlist_bitlist_513_nil_0() {
 
 #[test]
 fn test_bitlist_bitlist_513_nil_1() {
-    let mut value =
+    let value =
         <Bitlist<513> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -3854,7 +3848,7 @@ fn test_bitlist_bitlist_513_nil_1() {
     let recovered_value: Bitlist<513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x28ba1834a3a7b657460ce79fa3a1d909ab8828fd557659d4d0554a9bdbc0ec30");
     assert_eq!(root, expected_root);
@@ -3862,7 +3856,7 @@ fn test_bitlist_bitlist_513_nil_1() {
 
 #[test]
 fn test_bitlist_bitlist_513_nil_2() {
-    let mut value =
+    let value =
         <Bitlist<513> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -3873,7 +3867,7 @@ fn test_bitlist_bitlist_513_nil_2() {
     let recovered_value: Bitlist<513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x28ba1834a3a7b657460ce79fa3a1d909ab8828fd557659d4d0554a9bdbc0ec30");
     assert_eq!(root, expected_root);
@@ -3881,7 +3875,7 @@ fn test_bitlist_bitlist_513_nil_2() {
 
 #[test]
 fn test_bitlist_bitlist_513_nil_3() {
-    let mut value =
+    let value =
         <Bitlist<513> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -3892,7 +3886,7 @@ fn test_bitlist_bitlist_513_nil_3() {
     let recovered_value: Bitlist<513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x28ba1834a3a7b657460ce79fa3a1d909ab8828fd557659d4d0554a9bdbc0ec30");
     assert_eq!(root, expected_root);
@@ -3900,7 +3894,7 @@ fn test_bitlist_bitlist_513_nil_3() {
 
 #[test]
 fn test_bitlist_bitlist_513_nil_4() {
-    let mut value =
+    let value =
         <Bitlist<513> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -3911,7 +3905,7 @@ fn test_bitlist_bitlist_513_nil_4() {
     let recovered_value: Bitlist<513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x28ba1834a3a7b657460ce79fa3a1d909ab8828fd557659d4d0554a9bdbc0ec30");
     assert_eq!(root, expected_root);
@@ -3919,7 +3913,7 @@ fn test_bitlist_bitlist_513_nil_4() {
 
 #[test]
 fn test_bitlist_bitlist_513_random_0() {
-    let mut value = <Bitlist<513> as TryFrom<&[u8]>>::try_from(
+    let value = <Bitlist<513> as TryFrom<&[u8]>>::try_from(
         Vec::<u8>::from_iter([176, 215, 228, 180, 55, 102, 22, 56, 171, 0, 210, 26]).as_ref(),
     )
     .unwrap();
@@ -3932,7 +3926,7 @@ fn test_bitlist_bitlist_513_random_0() {
     let recovered_value: Bitlist<513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x62110ea980c0e8b321149e2681d66a3c9ca6d2af615ed3f7b2ea1f950519cee3");
     assert_eq!(root, expected_root);
@@ -3940,7 +3934,7 @@ fn test_bitlist_bitlist_513_random_0() {
 
 #[test]
 fn test_bitlist_bitlist_513_random_1() {
-    let mut value = <Bitlist<513> as TryFrom<&[u8]>>::try_from(
+    let value = <Bitlist<513> as TryFrom<&[u8]>>::try_from(
         Vec::<u8>::from_iter([
             245, 161, 103, 135, 184, 153, 184, 107, 212, 115, 240, 116, 67, 139, 183, 180, 192, 56,
             42, 59, 93, 140, 253, 38, 235, 169, 190, 107, 72, 235, 179, 66, 239,
@@ -3957,7 +3951,7 @@ fn test_bitlist_bitlist_513_random_1() {
     let recovered_value: Bitlist<513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x339f84a3e78443af74c3ea49f06c6d1933f3b4e3440dc631820662651085a306");
     assert_eq!(root, expected_root);
@@ -3965,7 +3959,7 @@ fn test_bitlist_bitlist_513_random_1() {
 
 #[test]
 fn test_bitlist_bitlist_513_random_2() {
-    let mut value = <Bitlist<513> as TryFrom<&[u8]>>::try_from(
+    let value = <Bitlist<513> as TryFrom<&[u8]>>::try_from(
         Vec::<u8>::from_iter([
             186, 79, 229, 99, 225, 114, 253, 235, 154, 116, 179, 60, 152, 109, 119, 170, 93, 63,
             174, 162, 177, 182, 89, 12, 145, 140, 95, 44, 142, 239, 49, 74, 73, 181, 146, 240, 65,
@@ -3983,7 +3977,7 @@ fn test_bitlist_bitlist_513_random_2() {
     let recovered_value: Bitlist<513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xbb76eb1bab23fc2865c84717251e4305221771924259082d793d3bbaa6444ba1");
     assert_eq!(root, expected_root);
@@ -3991,7 +3985,7 @@ fn test_bitlist_bitlist_513_random_2() {
 
 #[test]
 fn test_bitlist_bitlist_513_random_3() {
-    let mut value = <Bitlist<513> as TryFrom<&[u8]>>::try_from(
+    let value = <Bitlist<513> as TryFrom<&[u8]>>::try_from(
         Vec::<u8>::from_iter([218, 86, 210, 218]).as_ref(),
     )
     .unwrap();
@@ -4004,7 +3998,7 @@ fn test_bitlist_bitlist_513_random_3() {
     let recovered_value: Bitlist<513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x32370b95731ef776a513ca5ef154a83ba935260f2f4bdbba23c21b33e12f7b62");
     assert_eq!(root, expected_root);
@@ -4012,7 +4006,7 @@ fn test_bitlist_bitlist_513_random_3() {
 
 #[test]
 fn test_bitlist_bitlist_513_random_4() {
-    let mut value = <Bitlist<513> as TryFrom<&[u8]>>::try_from(
+    let value = <Bitlist<513> as TryFrom<&[u8]>>::try_from(
         Vec::<u8>::from_iter([104, 76, 185, 82, 136, 235, 228, 30, 187, 193, 232, 34, 2]).as_ref(),
     )
     .unwrap();
@@ -4025,7 +4019,7 @@ fn test_bitlist_bitlist_513_random_4() {
     let recovered_value: Bitlist<513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xba02d7073304a825d35943f503cb081434b0b49713afdff5b5a6ab1f46d14171");
     assert_eq!(root, expected_root);
@@ -4033,7 +4027,7 @@ fn test_bitlist_bitlist_513_random_4() {
 
 #[test]
 fn test_bitlist_bitlist_513_zero_0() {
-    let mut value = <Bitlist<513> as TryFrom<&[u8]>>::try_from(
+    let value = <Bitlist<513> as TryFrom<&[u8]>>::try_from(
         Vec::<u8>::from_iter([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 2,
@@ -4050,7 +4044,7 @@ fn test_bitlist_bitlist_513_zero_0() {
     let recovered_value: Bitlist<513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x3f398072fb9acafba24683799d8250de322a96a12e3016134220db24526b372d");
     assert_eq!(root, expected_root);
@@ -4058,7 +4052,7 @@ fn test_bitlist_bitlist_513_zero_0() {
 
 #[test]
 fn test_bitlist_bitlist_513_zero_1() {
-    let mut value = <Bitlist<513> as TryFrom<&[u8]>>::try_from(
+    let value = <Bitlist<513> as TryFrom<&[u8]>>::try_from(
         Vec::<u8>::from_iter([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -4076,7 +4070,7 @@ fn test_bitlist_bitlist_513_zero_1() {
     let recovered_value: Bitlist<513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x25f3b33649409489b22232a7706a5ae5c4f5b62cadee098a758d3fa16d1087d2");
     assert_eq!(root, expected_root);
@@ -4084,7 +4078,7 @@ fn test_bitlist_bitlist_513_zero_1() {
 
 #[test]
 fn test_bitlist_bitlist_513_zero_2() {
-    let mut value =
+    let value =
         <Bitlist<513> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0, 0, 0, 0, 1]).as_ref())
             .unwrap();
     let encoding = serialize(&value);
@@ -4096,7 +4090,7 @@ fn test_bitlist_bitlist_513_zero_2() {
     let recovered_value: Bitlist<513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x38ab4aeb5726a3fb78af0101063f2586905c3e8466206bfc8777f44ed9e6ef20");
     assert_eq!(root, expected_root);
@@ -4104,7 +4098,7 @@ fn test_bitlist_bitlist_513_zero_2() {
 
 #[test]
 fn test_bitlist_bitlist_513_zero_3() {
-    let mut value = <Bitlist<513> as TryFrom<&[u8]>>::try_from(
+    let value = <Bitlist<513> as TryFrom<&[u8]>>::try_from(
         Vec::<u8>::from_iter([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4]).as_ref(),
     )
     .unwrap();
@@ -4117,7 +4111,7 @@ fn test_bitlist_bitlist_513_zero_3() {
     let recovered_value: Bitlist<513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x54bfe2c647e52bf3897cff9675165d53f277e1f7dbd7c620f630a2deb02ce0c8");
     assert_eq!(root, expected_root);
@@ -4125,7 +4119,7 @@ fn test_bitlist_bitlist_513_zero_3() {
 
 #[test]
 fn test_bitlist_bitlist_513_zero_4() {
-    let mut value = <Bitlist<513> as TryFrom<&[u8]>>::try_from(
+    let value = <Bitlist<513> as TryFrom<&[u8]>>::try_from(
         Vec::<u8>::from_iter([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 64,
@@ -4142,7 +4136,7 @@ fn test_bitlist_bitlist_513_zero_4() {
     let recovered_value: Bitlist<513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x9b7d4ffa3720c8ea2c66e59f1890a83c86ef2b4442a5ebe6d757fb4cbe0b3231");
     assert_eq!(root, expected_root);
@@ -4160,7 +4154,7 @@ fn test_bitlist_bitlist_5_but_6() {
 
 #[test]
 fn test_bitlist_bitlist_5_lengthy_0() {
-    let mut value =
+    let value =
         <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([36]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -4171,7 +4165,7 @@ fn test_bitlist_bitlist_5_lengthy_0() {
     let recovered_value: Bitlist<5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xbd50456d5ad175ae99a1612a53ca229124b65d3eaabd9ff9c7ab979a385cf6b3");
     assert_eq!(root, expected_root);
@@ -4179,7 +4173,7 @@ fn test_bitlist_bitlist_5_lengthy_0() {
 
 #[test]
 fn test_bitlist_bitlist_5_lengthy_1() {
-    let mut value =
+    let value =
         <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([57]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -4190,7 +4184,7 @@ fn test_bitlist_bitlist_5_lengthy_1() {
     let recovered_value: Bitlist<5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x7000b9bd26fb753d24a4ed870faee659894843b795377a89ade25b649246e773");
     assert_eq!(root, expected_root);
@@ -4198,7 +4192,7 @@ fn test_bitlist_bitlist_5_lengthy_1() {
 
 #[test]
 fn test_bitlist_bitlist_5_lengthy_2() {
-    let mut value =
+    let value =
         <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([34]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -4209,7 +4203,7 @@ fn test_bitlist_bitlist_5_lengthy_2() {
     let recovered_value: Bitlist<5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xd13061c7b549c86b29ad2389cbe4fb2fd05bbdf3170da634e67f77ab981b82cb");
     assert_eq!(root, expected_root);
@@ -4217,7 +4211,7 @@ fn test_bitlist_bitlist_5_lengthy_2() {
 
 #[test]
 fn test_bitlist_bitlist_5_lengthy_3() {
-    let mut value =
+    let value =
         <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([58]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -4228,7 +4222,7 @@ fn test_bitlist_bitlist_5_lengthy_3() {
     let recovered_value: Bitlist<5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x5d40a4acd8c5f8b674c29a7b7814a546fade497a96d0e7bb51c3a4951fb1fa7e");
     assert_eq!(root, expected_root);
@@ -4236,7 +4230,7 @@ fn test_bitlist_bitlist_5_lengthy_3() {
 
 #[test]
 fn test_bitlist_bitlist_5_lengthy_4() {
-    let mut value =
+    let value =
         <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([48]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -4247,7 +4241,7 @@ fn test_bitlist_bitlist_5_lengthy_4() {
     let recovered_value: Bitlist<5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x88b744d02033bbb6a4ebc2dc3f31c4910681596c7bcb9349d9483a33e45899c7");
     assert_eq!(root, expected_root);
@@ -4255,7 +4249,7 @@ fn test_bitlist_bitlist_5_lengthy_4() {
 
 #[test]
 fn test_bitlist_bitlist_5_max_0() {
-    let mut value =
+    let value =
         <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([15]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -4266,7 +4260,7 @@ fn test_bitlist_bitlist_5_max_0() {
     let recovered_value: Bitlist<5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x251d8bd955c85219bb8f6de682810b4aafe3e0c3d3c624020fb39f81dbb85910");
     assert_eq!(root, expected_root);
@@ -4274,7 +4268,7 @@ fn test_bitlist_bitlist_5_max_0() {
 
 #[test]
 fn test_bitlist_bitlist_5_max_1() {
-    let mut value =
+    let value =
         <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([15]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -4285,7 +4279,7 @@ fn test_bitlist_bitlist_5_max_1() {
     let recovered_value: Bitlist<5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x251d8bd955c85219bb8f6de682810b4aafe3e0c3d3c624020fb39f81dbb85910");
     assert_eq!(root, expected_root);
@@ -4293,7 +4287,7 @@ fn test_bitlist_bitlist_5_max_1() {
 
 #[test]
 fn test_bitlist_bitlist_5_max_2() {
-    let mut value =
+    let value =
         <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([31]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -4304,7 +4298,7 @@ fn test_bitlist_bitlist_5_max_2() {
     let recovered_value: Bitlist<5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x4b07c3799db025f3aa92ced1e8545367a2b6e44960f479d3f9d62b61812892d5");
     assert_eq!(root, expected_root);
@@ -4312,7 +4306,7 @@ fn test_bitlist_bitlist_5_max_2() {
 
 #[test]
 fn test_bitlist_bitlist_5_max_3() {
-    let mut value =
+    let value =
         <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([31]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -4323,7 +4317,7 @@ fn test_bitlist_bitlist_5_max_3() {
     let recovered_value: Bitlist<5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x4b07c3799db025f3aa92ced1e8545367a2b6e44960f479d3f9d62b61812892d5");
     assert_eq!(root, expected_root);
@@ -4331,7 +4325,7 @@ fn test_bitlist_bitlist_5_max_3() {
 
 #[test]
 fn test_bitlist_bitlist_5_max_4() {
-    let mut value =
+    let value =
         <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([7]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -4342,7 +4336,7 @@ fn test_bitlist_bitlist_5_max_4() {
     let recovered_value: Bitlist<5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xc397e31994d6b872c69af43765ab16a1cef673be726a820dacd2637bea2f5fbb");
     assert_eq!(root, expected_root);
@@ -4350,7 +4344,7 @@ fn test_bitlist_bitlist_5_max_4() {
 
 #[test]
 fn test_bitlist_bitlist_5_nil_0() {
-    let mut value =
+    let value =
         <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -4361,7 +4355,7 @@ fn test_bitlist_bitlist_5_nil_0() {
     let recovered_value: Bitlist<5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -4369,7 +4363,7 @@ fn test_bitlist_bitlist_5_nil_0() {
 
 #[test]
 fn test_bitlist_bitlist_5_nil_1() {
-    let mut value =
+    let value =
         <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -4380,7 +4374,7 @@ fn test_bitlist_bitlist_5_nil_1() {
     let recovered_value: Bitlist<5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -4388,7 +4382,7 @@ fn test_bitlist_bitlist_5_nil_1() {
 
 #[test]
 fn test_bitlist_bitlist_5_nil_2() {
-    let mut value =
+    let value =
         <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -4399,7 +4393,7 @@ fn test_bitlist_bitlist_5_nil_2() {
     let recovered_value: Bitlist<5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -4407,7 +4401,7 @@ fn test_bitlist_bitlist_5_nil_2() {
 
 #[test]
 fn test_bitlist_bitlist_5_nil_3() {
-    let mut value =
+    let value =
         <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -4418,7 +4412,7 @@ fn test_bitlist_bitlist_5_nil_3() {
     let recovered_value: Bitlist<5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -4426,7 +4420,7 @@ fn test_bitlist_bitlist_5_nil_3() {
 
 #[test]
 fn test_bitlist_bitlist_5_nil_4() {
-    let mut value =
+    let value =
         <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -4437,7 +4431,7 @@ fn test_bitlist_bitlist_5_nil_4() {
     let recovered_value: Bitlist<5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -4445,7 +4439,7 @@ fn test_bitlist_bitlist_5_nil_4() {
 
 #[test]
 fn test_bitlist_bitlist_5_random_0() {
-    let mut value =
+    let value =
         <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -4456,7 +4450,7 @@ fn test_bitlist_bitlist_5_random_0() {
     let recovered_value: Bitlist<5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -4464,7 +4458,7 @@ fn test_bitlist_bitlist_5_random_0() {
 
 #[test]
 fn test_bitlist_bitlist_5_random_1() {
-    let mut value =
+    let value =
         <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([8]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -4475,7 +4469,7 @@ fn test_bitlist_bitlist_5_random_1() {
     let recovered_value: Bitlist<5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xd86ae2ca925345bf2412bde450ac175742d979c1ea7b961bd1efe10beb9500cf");
     assert_eq!(root, expected_root);
@@ -4483,7 +4477,7 @@ fn test_bitlist_bitlist_5_random_1() {
 
 #[test]
 fn test_bitlist_bitlist_5_random_2() {
-    let mut value =
+    let value =
         <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([3]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -4494,7 +4488,7 @@ fn test_bitlist_bitlist_5_random_2() {
     let recovered_value: Bitlist<5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x56d8a66fbae0300efba7ec2c531973aaae22e7a2ed6ded081b5b32d07a32780a");
     assert_eq!(root, expected_root);
@@ -4502,7 +4496,7 @@ fn test_bitlist_bitlist_5_random_2() {
 
 #[test]
 fn test_bitlist_bitlist_5_random_3() {
-    let mut value =
+    let value =
         <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([6]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -4513,7 +4507,7 @@ fn test_bitlist_bitlist_5_random_3() {
     let recovered_value: Bitlist<5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0e01f8d9a6720610a44a70c2c91bbe750ec6cd67892d92b1016394abfc382cf9");
     assert_eq!(root, expected_root);
@@ -4521,7 +4515,7 @@ fn test_bitlist_bitlist_5_random_3() {
 
 #[test]
 fn test_bitlist_bitlist_5_random_4() {
-    let mut value =
+    let value =
         <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([22]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -4532,7 +4526,7 @@ fn test_bitlist_bitlist_5_random_4() {
     let recovered_value: Bitlist<5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x894e8a2ce460c6c6ba12d467634e6c34ce2a1b58d0c6dfe3d98b532898c58611");
     assert_eq!(root, expected_root);
@@ -4540,7 +4534,7 @@ fn test_bitlist_bitlist_5_random_4() {
 
 #[test]
 fn test_bitlist_bitlist_5_zero_0() {
-    let mut value =
+    let value =
         <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([4]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -4551,7 +4545,7 @@ fn test_bitlist_bitlist_5_zero_0() {
     let recovered_value: Bitlist<5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x1205f4789155711e2542dba1a64d226626fe3eb43baa854752d0b59077e010fc");
     assert_eq!(root, expected_root);
@@ -4559,7 +4553,7 @@ fn test_bitlist_bitlist_5_zero_0() {
 
 #[test]
 fn test_bitlist_bitlist_5_zero_1() {
-    let mut value =
+    let value =
         <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([32]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -4570,7 +4564,7 @@ fn test_bitlist_bitlist_5_zero_1() {
     let recovered_value: Bitlist<5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x16aaf795af421b6156d4c3319879d422a0c3ffd26db07207a54d6cafcbef0b10");
     assert_eq!(root, expected_root);
@@ -4578,7 +4572,7 @@ fn test_bitlist_bitlist_5_zero_1() {
 
 #[test]
 fn test_bitlist_bitlist_5_zero_2() {
-    let mut value =
+    let value =
         <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([16]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -4589,7 +4583,7 @@ fn test_bitlist_bitlist_5_zero_2() {
     let recovered_value: Bitlist<5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xd647eb2598d33d7216256356596d29cecd31c1ba7a7ff25ccb5be4a453410b9d");
     assert_eq!(root, expected_root);
@@ -4597,7 +4591,7 @@ fn test_bitlist_bitlist_5_zero_2() {
 
 #[test]
 fn test_bitlist_bitlist_5_zero_3() {
-    let mut value =
+    let value =
         <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([2]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -4608,7 +4602,7 @@ fn test_bitlist_bitlist_5_zero_3() {
     let recovered_value: Bitlist<5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xcb592844121d926f1ca3ad4e1d6fb9d8e260ed6e3216361f7732e975a0e8bbf6");
     assert_eq!(root, expected_root);
@@ -4616,7 +4610,7 @@ fn test_bitlist_bitlist_5_zero_3() {
 
 #[test]
 fn test_bitlist_bitlist_5_zero_4() {
-    let mut value =
+    let value =
         <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([16]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -4627,7 +4621,7 @@ fn test_bitlist_bitlist_5_zero_4() {
     let recovered_value: Bitlist<5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xd647eb2598d33d7216256356596d29cecd31c1ba7a7ff25ccb5be4a453410b9d");
     assert_eq!(root, expected_root);
@@ -4645,7 +4639,7 @@ fn test_bitlist_bitlist_8_but_9() {
 
 #[test]
 fn test_bitlist_bitlist_8_lengthy_0() {
-    let mut value =
+    let value =
         <Bitlist<8> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([206, 1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -4656,7 +4650,7 @@ fn test_bitlist_bitlist_8_lengthy_0() {
     let recovered_value: Bitlist<8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x095847dd477b5ac2b2a5930d0633975f09e835630c2d4a832b6469e8c0d106d1");
     assert_eq!(root, expected_root);
@@ -4664,7 +4658,7 @@ fn test_bitlist_bitlist_8_lengthy_0() {
 
 #[test]
 fn test_bitlist_bitlist_8_lengthy_1() {
-    let mut value =
+    let value =
         <Bitlist<8> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([180, 1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -4675,7 +4669,7 @@ fn test_bitlist_bitlist_8_lengthy_1() {
     let recovered_value: Bitlist<8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x5b6af4c3df02247b90fc3736e0a2ff746b5a7f7dc54e7edc66bbb0f68f1b7206");
     assert_eq!(root, expected_root);
@@ -4683,7 +4677,7 @@ fn test_bitlist_bitlist_8_lengthy_1() {
 
 #[test]
 fn test_bitlist_bitlist_8_lengthy_2() {
-    let mut value =
+    let value =
         <Bitlist<8> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([83, 1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -4694,7 +4688,7 @@ fn test_bitlist_bitlist_8_lengthy_2() {
     let recovered_value: Bitlist<8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xeeb7a380c63f2182c38a556ee4170cb9fd06b86b5014181e7a01ce0097627cf0");
     assert_eq!(root, expected_root);
@@ -4702,7 +4696,7 @@ fn test_bitlist_bitlist_8_lengthy_2() {
 
 #[test]
 fn test_bitlist_bitlist_8_lengthy_3() {
-    let mut value =
+    let value =
         <Bitlist<8> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([99, 1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -4713,7 +4707,7 @@ fn test_bitlist_bitlist_8_lengthy_3() {
     let recovered_value: Bitlist<8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xb8148b13b48faa79622d9a6975e7abdf85dd4639a25e53412eb0aa5c34386019");
     assert_eq!(root, expected_root);
@@ -4721,7 +4715,7 @@ fn test_bitlist_bitlist_8_lengthy_3() {
 
 #[test]
 fn test_bitlist_bitlist_8_lengthy_4() {
-    let mut value =
+    let value =
         <Bitlist<8> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([227, 1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -4732,7 +4726,7 @@ fn test_bitlist_bitlist_8_lengthy_4() {
     let recovered_value: Bitlist<8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x6d1fd4c1b192e8aeb35074214855c593805c2ed1ff79f7aa7c6128814fa41bf3");
     assert_eq!(root, expected_root);
@@ -4740,7 +4734,7 @@ fn test_bitlist_bitlist_8_lengthy_4() {
 
 #[test]
 fn test_bitlist_bitlist_8_max_0() {
-    let mut value =
+    let value =
         <Bitlist<8> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([255, 1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -4751,7 +4745,7 @@ fn test_bitlist_bitlist_8_max_0() {
     let recovered_value: Bitlist<8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x017d2fa0f6934ed2354e4cdb7a2230ccf8f31fe758c7a47442e37fdea1d68bfe");
     assert_eq!(root, expected_root);
@@ -4759,7 +4753,7 @@ fn test_bitlist_bitlist_8_max_0() {
 
 #[test]
 fn test_bitlist_bitlist_8_max_1() {
-    let mut value =
+    let value =
         <Bitlist<8> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([255, 1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -4770,7 +4764,7 @@ fn test_bitlist_bitlist_8_max_1() {
     let recovered_value: Bitlist<8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x017d2fa0f6934ed2354e4cdb7a2230ccf8f31fe758c7a47442e37fdea1d68bfe");
     assert_eq!(root, expected_root);
@@ -4778,7 +4772,7 @@ fn test_bitlist_bitlist_8_max_1() {
 
 #[test]
 fn test_bitlist_bitlist_8_max_2() {
-    let mut value =
+    let value =
         <Bitlist<8> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -4789,7 +4783,7 @@ fn test_bitlist_bitlist_8_max_2() {
     let recovered_value: Bitlist<8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -4797,7 +4791,7 @@ fn test_bitlist_bitlist_8_max_2() {
 
 #[test]
 fn test_bitlist_bitlist_8_max_3() {
-    let mut value =
+    let value =
         <Bitlist<8> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([63]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -4808,7 +4802,7 @@ fn test_bitlist_bitlist_8_max_3() {
     let recovered_value: Bitlist<8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xcb9e73cb5c2e4ef66fa63540f8220301d31eea7edfccedb2b47b9bdf849ccee7");
     assert_eq!(root, expected_root);
@@ -4816,7 +4810,7 @@ fn test_bitlist_bitlist_8_max_3() {
 
 #[test]
 fn test_bitlist_bitlist_8_max_4() {
-    let mut value =
+    let value =
         <Bitlist<8> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -4827,7 +4821,7 @@ fn test_bitlist_bitlist_8_max_4() {
     let recovered_value: Bitlist<8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -4835,7 +4829,7 @@ fn test_bitlist_bitlist_8_max_4() {
 
 #[test]
 fn test_bitlist_bitlist_8_nil_0() {
-    let mut value =
+    let value =
         <Bitlist<8> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -4846,7 +4840,7 @@ fn test_bitlist_bitlist_8_nil_0() {
     let recovered_value: Bitlist<8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -4854,7 +4848,7 @@ fn test_bitlist_bitlist_8_nil_0() {
 
 #[test]
 fn test_bitlist_bitlist_8_nil_1() {
-    let mut value =
+    let value =
         <Bitlist<8> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -4865,7 +4859,7 @@ fn test_bitlist_bitlist_8_nil_1() {
     let recovered_value: Bitlist<8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -4873,7 +4867,7 @@ fn test_bitlist_bitlist_8_nil_1() {
 
 #[test]
 fn test_bitlist_bitlist_8_nil_2() {
-    let mut value =
+    let value =
         <Bitlist<8> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -4884,7 +4878,7 @@ fn test_bitlist_bitlist_8_nil_2() {
     let recovered_value: Bitlist<8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -4892,7 +4886,7 @@ fn test_bitlist_bitlist_8_nil_2() {
 
 #[test]
 fn test_bitlist_bitlist_8_nil_3() {
-    let mut value =
+    let value =
         <Bitlist<8> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -4903,7 +4897,7 @@ fn test_bitlist_bitlist_8_nil_3() {
     let recovered_value: Bitlist<8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -4911,7 +4905,7 @@ fn test_bitlist_bitlist_8_nil_3() {
 
 #[test]
 fn test_bitlist_bitlist_8_nil_4() {
-    let mut value =
+    let value =
         <Bitlist<8> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -4922,7 +4916,7 @@ fn test_bitlist_bitlist_8_nil_4() {
     let recovered_value: Bitlist<8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -4930,7 +4924,7 @@ fn test_bitlist_bitlist_8_nil_4() {
 
 #[test]
 fn test_bitlist_bitlist_8_random_0() {
-    let mut value =
+    let value =
         <Bitlist<8> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([79]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -4941,7 +4935,7 @@ fn test_bitlist_bitlist_8_random_0() {
     let recovered_value: Bitlist<8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x385e8de0fb7865579bcaf9d0a9c86e4cca08a6911d1ce85530f96ce202a38d21");
     assert_eq!(root, expected_root);
@@ -4949,7 +4943,7 @@ fn test_bitlist_bitlist_8_random_0() {
 
 #[test]
 fn test_bitlist_bitlist_8_random_1() {
-    let mut value =
+    let value =
         <Bitlist<8> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([4]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -4960,7 +4954,7 @@ fn test_bitlist_bitlist_8_random_1() {
     let recovered_value: Bitlist<8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x1205f4789155711e2542dba1a64d226626fe3eb43baa854752d0b59077e010fc");
     assert_eq!(root, expected_root);
@@ -4968,7 +4962,7 @@ fn test_bitlist_bitlist_8_random_1() {
 
 #[test]
 fn test_bitlist_bitlist_8_random_2() {
-    let mut value =
+    let value =
         <Bitlist<8> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([2]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -4979,7 +4973,7 @@ fn test_bitlist_bitlist_8_random_2() {
     let recovered_value: Bitlist<8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xcb592844121d926f1ca3ad4e1d6fb9d8e260ed6e3216361f7732e975a0e8bbf6");
     assert_eq!(root, expected_root);
@@ -4987,7 +4981,7 @@ fn test_bitlist_bitlist_8_random_2() {
 
 #[test]
 fn test_bitlist_bitlist_8_random_3() {
-    let mut value =
+    let value =
         <Bitlist<8> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([2]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -4998,7 +4992,7 @@ fn test_bitlist_bitlist_8_random_3() {
     let recovered_value: Bitlist<8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xcb592844121d926f1ca3ad4e1d6fb9d8e260ed6e3216361f7732e975a0e8bbf6");
     assert_eq!(root, expected_root);
@@ -5006,7 +5000,7 @@ fn test_bitlist_bitlist_8_random_3() {
 
 #[test]
 fn test_bitlist_bitlist_8_random_4() {
-    let mut value =
+    let value =
         <Bitlist<8> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([15]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -5017,7 +5011,7 @@ fn test_bitlist_bitlist_8_random_4() {
     let recovered_value: Bitlist<8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x251d8bd955c85219bb8f6de682810b4aafe3e0c3d3c624020fb39f81dbb85910");
     assert_eq!(root, expected_root);
@@ -5025,7 +5019,7 @@ fn test_bitlist_bitlist_8_random_4() {
 
 #[test]
 fn test_bitlist_bitlist_8_zero_0() {
-    let mut value =
+    let value =
         <Bitlist<8> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([64]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -5036,7 +5030,7 @@ fn test_bitlist_bitlist_8_zero_0() {
     let recovered_value: Bitlist<8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x7d360196d14b15261c9e5f576df8dc8b48d18d79b4198f167741052747704352");
     assert_eq!(root, expected_root);
@@ -5044,7 +5038,7 @@ fn test_bitlist_bitlist_8_zero_0() {
 
 #[test]
 fn test_bitlist_bitlist_8_zero_1() {
-    let mut value =
+    let value =
         <Bitlist<8> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([4]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -5055,7 +5049,7 @@ fn test_bitlist_bitlist_8_zero_1() {
     let recovered_value: Bitlist<8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x1205f4789155711e2542dba1a64d226626fe3eb43baa854752d0b59077e010fc");
     assert_eq!(root, expected_root);
@@ -5063,7 +5057,7 @@ fn test_bitlist_bitlist_8_zero_1() {
 
 #[test]
 fn test_bitlist_bitlist_8_zero_2() {
-    let mut value =
+    let value =
         <Bitlist<8> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([64]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -5074,7 +5068,7 @@ fn test_bitlist_bitlist_8_zero_2() {
     let recovered_value: Bitlist<8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x7d360196d14b15261c9e5f576df8dc8b48d18d79b4198f167741052747704352");
     assert_eq!(root, expected_root);
@@ -5082,7 +5076,7 @@ fn test_bitlist_bitlist_8_zero_2() {
 
 #[test]
 fn test_bitlist_bitlist_8_zero_3() {
-    let mut value =
+    let value =
         <Bitlist<8> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([64]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -5093,7 +5087,7 @@ fn test_bitlist_bitlist_8_zero_3() {
     let recovered_value: Bitlist<8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x7d360196d14b15261c9e5f576df8dc8b48d18d79b4198f167741052747704352");
     assert_eq!(root, expected_root);
@@ -5101,7 +5095,7 @@ fn test_bitlist_bitlist_8_zero_3() {
 
 #[test]
 fn test_bitlist_bitlist_8_zero_4() {
-    let mut value =
+    let value =
         <Bitlist<8> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([16]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -5112,7 +5106,7 @@ fn test_bitlist_bitlist_8_zero_4() {
     let recovered_value: Bitlist<8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xd647eb2598d33d7216256356596d29cecd31c1ba7a7ff25ccb5be4a453410b9d");
     assert_eq!(root, expected_root);

--- a/ssz-rs/tests/bitvector.rs
+++ b/ssz-rs/tests/bitvector.rs
@@ -18,7 +18,7 @@ fn test_bitvector_bitvec_0() {
 
 #[test]
 fn test_bitvector_bitvec_16_max() {
-    let mut value =
+    let value =
         <Bitvector<16> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([255, 255]).as_ref())
             .unwrap();
     let encoding = serialize(&value);
@@ -30,7 +30,7 @@ fn test_bitvector_bitvec_16_max() {
     let recovered_value: Bitvector<16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xffff000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -48,7 +48,7 @@ fn test_bitvector_bitvec_16_max_8() {
 
 #[test]
 fn test_bitvector_bitvec_16_random() {
-    let mut value =
+    let value =
         <Bitvector<16> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([46, 236]).as_ref())
             .unwrap();
     let encoding = serialize(&value);
@@ -60,7 +60,7 @@ fn test_bitvector_bitvec_16_random() {
     let recovered_value: Bitvector<16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x2eec000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -78,7 +78,7 @@ fn test_bitvector_bitvec_16_random_8() {
 
 #[test]
 fn test_bitvector_bitvec_16_zero() {
-    let mut value =
+    let value =
         <Bitvector<16> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0, 0]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -89,7 +89,7 @@ fn test_bitvector_bitvec_16_zero() {
     let recovered_value: Bitvector<16> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -107,7 +107,7 @@ fn test_bitvector_bitvec_16_zero_8() {
 
 #[test]
 fn test_bitvector_bitvec_1_max() {
-    let mut value =
+    let value =
         <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -118,7 +118,7 @@ fn test_bitvector_bitvec_1_max() {
     let recovered_value: Bitvector<1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0100000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -136,7 +136,7 @@ fn test_bitvector_bitvec_1_max_2() {
 
 #[test]
 fn test_bitvector_bitvec_1_random() {
-    let mut value =
+    let value =
         <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -147,7 +147,7 @@ fn test_bitvector_bitvec_1_random() {
     let recovered_value: Bitvector<1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -165,7 +165,7 @@ fn test_bitvector_bitvec_1_random_2() {
 
 #[test]
 fn test_bitvector_bitvec_1_zero() {
-    let mut value =
+    let value =
         <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -176,7 +176,7 @@ fn test_bitvector_bitvec_1_zero() {
     let recovered_value: Bitvector<1> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -194,7 +194,7 @@ fn test_bitvector_bitvec_1_zero_2() {
 
 #[test]
 fn test_bitvector_bitvec_2_max() {
-    let mut value =
+    let value =
         <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([3]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -205,7 +205,7 @@ fn test_bitvector_bitvec_2_max() {
     let recovered_value: Bitvector<2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0300000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -223,7 +223,7 @@ fn test_bitvector_bitvec_2_max_3() {
 
 #[test]
 fn test_bitvector_bitvec_2_random() {
-    let mut value =
+    let value =
         <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([3]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -234,7 +234,7 @@ fn test_bitvector_bitvec_2_random() {
     let recovered_value: Bitvector<2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0300000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -252,7 +252,7 @@ fn test_bitvector_bitvec_2_random_3() {
 
 #[test]
 fn test_bitvector_bitvec_2_zero() {
-    let mut value =
+    let value =
         <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -263,7 +263,7 @@ fn test_bitvector_bitvec_2_zero() {
     let recovered_value: Bitvector<2> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -281,7 +281,7 @@ fn test_bitvector_bitvec_2_zero_3() {
 
 #[test]
 fn test_bitvector_bitvec_31_max() {
-    let mut value = <Bitvector<31> as TryFrom<&[u8]>>::try_from(
+    let value = <Bitvector<31> as TryFrom<&[u8]>>::try_from(
         Vec::<u8>::from_iter([255, 255, 255, 127]).as_ref(),
     )
     .unwrap();
@@ -294,7 +294,7 @@ fn test_bitvector_bitvec_31_max() {
     let recovered_value: Bitvector<31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xffffff7f00000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -302,7 +302,7 @@ fn test_bitvector_bitvec_31_max() {
 
 #[test]
 fn test_bitvector_bitvec_31_random() {
-    let mut value = <Bitvector<31> as TryFrom<&[u8]>>::try_from(
+    let value = <Bitvector<31> as TryFrom<&[u8]>>::try_from(
         Vec::<u8>::from_iter([114, 223, 100, 21]).as_ref(),
     )
     .unwrap();
@@ -315,7 +315,7 @@ fn test_bitvector_bitvec_31_random() {
     let recovered_value: Bitvector<31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x72df641500000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -323,7 +323,7 @@ fn test_bitvector_bitvec_31_random() {
 
 #[test]
 fn test_bitvector_bitvec_31_zero() {
-    let mut value =
+    let value =
         <Bitvector<31> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0, 0, 0, 0]).as_ref())
             .unwrap();
     let encoding = serialize(&value);
@@ -335,7 +335,7 @@ fn test_bitvector_bitvec_31_zero() {
     let recovered_value: Bitvector<31> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -373,7 +373,7 @@ fn test_bitvector_bitvec_32_zero_33() {
 
 #[test]
 fn test_bitvector_bitvec_3_max() {
-    let mut value =
+    let value =
         <Bitvector<3> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([7]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -384,7 +384,7 @@ fn test_bitvector_bitvec_3_max() {
     let recovered_value: Bitvector<3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0700000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -402,7 +402,7 @@ fn test_bitvector_bitvec_3_max_4() {
 
 #[test]
 fn test_bitvector_bitvec_3_random() {
-    let mut value =
+    let value =
         <Bitvector<3> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([7]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -413,7 +413,7 @@ fn test_bitvector_bitvec_3_random() {
     let recovered_value: Bitvector<3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0700000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -431,7 +431,7 @@ fn test_bitvector_bitvec_3_random_4() {
 
 #[test]
 fn test_bitvector_bitvec_3_zero() {
-    let mut value =
+    let value =
         <Bitvector<3> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -442,7 +442,7 @@ fn test_bitvector_bitvec_3_zero() {
     let recovered_value: Bitvector<3> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -460,7 +460,7 @@ fn test_bitvector_bitvec_3_zero_4() {
 
 #[test]
 fn test_bitvector_bitvec_4_max() {
-    let mut value =
+    let value =
         <Bitvector<4> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([15]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -471,7 +471,7 @@ fn test_bitvector_bitvec_4_max() {
     let recovered_value: Bitvector<4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0f00000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -489,7 +489,7 @@ fn test_bitvector_bitvec_4_max_5() {
 
 #[test]
 fn test_bitvector_bitvec_4_random() {
-    let mut value =
+    let value =
         <Bitvector<4> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([13]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -500,7 +500,7 @@ fn test_bitvector_bitvec_4_random() {
     let recovered_value: Bitvector<4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0d00000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -518,7 +518,7 @@ fn test_bitvector_bitvec_4_random_5() {
 
 #[test]
 fn test_bitvector_bitvec_4_zero() {
-    let mut value =
+    let value =
         <Bitvector<4> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -529,7 +529,7 @@ fn test_bitvector_bitvec_4_zero() {
     let recovered_value: Bitvector<4> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -547,7 +547,7 @@ fn test_bitvector_bitvec_4_zero_5() {
 
 #[test]
 fn test_bitvector_bitvec_512_max() {
-    let mut value = <Bitvector<512> as TryFrom<&[u8]>>::try_from(
+    let value = <Bitvector<512> as TryFrom<&[u8]>>::try_from(
         Vec::<u8>::from_iter([
             255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
             255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
@@ -566,7 +566,7 @@ fn test_bitvector_bitvec_512_max() {
     let recovered_value: Bitvector<512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x8667e718294e9e0df1d30600ba3eeb201f764aad2dad72748643e4a285e1d1f7");
     assert_eq!(root, expected_root);
@@ -584,7 +584,7 @@ fn test_bitvector_bitvec_512_max_513() {
 
 #[test]
 fn test_bitvector_bitvec_512_random() {
-    let mut value = <Bitvector<512> as TryFrom<&[u8]>>::try_from(
+    let value = <Bitvector<512> as TryFrom<&[u8]>>::try_from(
         Vec::<u8>::from_iter([
             80, 152, 209, 178, 29, 181, 106, 197, 239, 143, 96, 144, 164, 12, 18, 211, 12, 52, 56,
             123, 68, 155, 79, 101, 99, 209, 248, 11, 40, 23, 218, 4, 52, 27, 132, 94, 218, 129,
@@ -603,7 +603,7 @@ fn test_bitvector_bitvec_512_random() {
     let recovered_value: Bitvector<512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xfbdb71e991457c4fd956e16be1ae1dc959bceaf00f692fec9431de3f0175655a");
     assert_eq!(root, expected_root);
@@ -621,7 +621,7 @@ fn test_bitvector_bitvec_512_random_513() {
 
 #[test]
 fn test_bitvector_bitvec_512_zero() {
-    let mut value = <Bitvector<512> as TryFrom<&[u8]>>::try_from(
+    let value = <Bitvector<512> as TryFrom<&[u8]>>::try_from(
         Vec::<u8>::from_iter([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -639,7 +639,7 @@ fn test_bitvector_bitvec_512_zero() {
     let recovered_value: Bitvector<512> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -657,7 +657,7 @@ fn test_bitvector_bitvec_512_zero_513() {
 
 #[test]
 fn test_bitvector_bitvec_513_max() {
-    let mut value = <Bitvector<513> as TryFrom<&[u8]>>::try_from(
+    let value = <Bitvector<513> as TryFrom<&[u8]>>::try_from(
         Vec::<u8>::from_iter([
             255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
             255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
@@ -676,7 +676,7 @@ fn test_bitvector_bitvec_513_max() {
     let recovered_value: Bitvector<513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x222dd9eebc6467de9788eb1c05ce9c2da8ecc89abdd38810925ce061d91236ef");
     assert_eq!(root, expected_root);
@@ -684,7 +684,7 @@ fn test_bitvector_bitvec_513_max() {
 
 #[test]
 fn test_bitvector_bitvec_513_random() {
-    let mut value = <Bitvector<513> as TryFrom<&[u8]>>::try_from(
+    let value = <Bitvector<513> as TryFrom<&[u8]>>::try_from(
         Vec::<u8>::from_iter([
             35, 7, 207, 77, 114, 9, 148, 22, 93, 128, 20, 64, 206, 32, 22, 204, 234, 200, 252, 243,
             1, 27, 216, 80, 138, 122, 252, 100, 16, 87, 153, 189, 121, 111, 50, 2, 193, 3, 227, 15,
@@ -703,7 +703,7 @@ fn test_bitvector_bitvec_513_random() {
     let recovered_value: Bitvector<513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x84f06e5024cc71b8162c3a96f4b743505481722da5a281a6aaa69791b9f79283");
     assert_eq!(root, expected_root);
@@ -711,7 +711,7 @@ fn test_bitvector_bitvec_513_random() {
 
 #[test]
 fn test_bitvector_bitvec_513_zero() {
-    let mut value = <Bitvector<513> as TryFrom<&[u8]>>::try_from(
+    let value = <Bitvector<513> as TryFrom<&[u8]>>::try_from(
         Vec::<u8>::from_iter([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -729,7 +729,7 @@ fn test_bitvector_bitvec_513_zero() {
     let recovered_value: Bitvector<513> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xdb56114e00fdd4c1f85c892bf35ac9a89289aaecb1ebd0a96cde606a748b5d71");
     assert_eq!(root, expected_root);
@@ -737,7 +737,7 @@ fn test_bitvector_bitvec_513_zero() {
 
 #[test]
 fn test_bitvector_bitvec_5_max() {
-    let mut value =
+    let value =
         <Bitvector<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([31]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -748,7 +748,7 @@ fn test_bitvector_bitvec_5_max() {
     let recovered_value: Bitvector<5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x1f00000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -766,7 +766,7 @@ fn test_bitvector_bitvec_5_max_6() {
 
 #[test]
 fn test_bitvector_bitvec_5_random() {
-    let mut value =
+    let value =
         <Bitvector<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([3]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -777,7 +777,7 @@ fn test_bitvector_bitvec_5_random() {
     let recovered_value: Bitvector<5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0300000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -795,7 +795,7 @@ fn test_bitvector_bitvec_5_random_6() {
 
 #[test]
 fn test_bitvector_bitvec_5_zero() {
-    let mut value =
+    let value =
         <Bitvector<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -806,7 +806,7 @@ fn test_bitvector_bitvec_5_zero() {
     let recovered_value: Bitvector<5> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -824,7 +824,7 @@ fn test_bitvector_bitvec_5_zero_6() {
 
 #[test]
 fn test_bitvector_bitvec_8_max() {
-    let mut value =
+    let value =
         <Bitvector<8> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([255]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -835,7 +835,7 @@ fn test_bitvector_bitvec_8_max() {
     let recovered_value: Bitvector<8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xff00000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -853,7 +853,7 @@ fn test_bitvector_bitvec_8_max_9() {
 
 #[test]
 fn test_bitvector_bitvec_8_random() {
-    let mut value =
+    let value =
         <Bitvector<8> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([223]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -864,7 +864,7 @@ fn test_bitvector_bitvec_8_random() {
     let recovered_value: Bitvector<8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xdf00000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -882,7 +882,7 @@ fn test_bitvector_bitvec_8_random_9() {
 
 #[test]
 fn test_bitvector_bitvec_8_zero() {
-    let mut value =
+    let value =
         <Bitvector<8> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap();
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
@@ -893,7 +893,7 @@ fn test_bitvector_bitvec_8_zero() {
     let recovered_value: Bitvector<8> = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);

--- a/ssz-rs/tests/boolean.rs
+++ b/ssz-rs/tests/boolean.rs
@@ -48,7 +48,7 @@ fn test_boolean_byte_rev_nibble() {
 
 #[test]
 fn test_boolean_false() {
-    let mut value = false;
+    let value = false;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/boolean/valid/false/serialized.ssz_snappy",
@@ -58,7 +58,7 @@ fn test_boolean_false() {
     let recovered_value: bool = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -66,7 +66,7 @@ fn test_boolean_false() {
 
 #[test]
 fn test_boolean_true() {
-    let mut value = true;
+    let value = true;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/boolean/valid/true/serialized.ssz_snappy",
@@ -76,7 +76,7 @@ fn test_boolean_true() {
     let recovered_value: bool = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0100000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);

--- a/ssz-rs/tests/containers.rs
+++ b/ssz-rs/tests/containers.rs
@@ -63,7 +63,7 @@ fn test_containers_bits_struct_extra_byte() {
 
 #[test]
 fn test_containers_bits_struct_lengthy_0() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([46]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([2]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
@@ -80,7 +80,7 @@ fn test_containers_bits_struct_lengthy_0() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x9c6ecf69a7358d02abee9eb030842f538e13cf10d67747887f0e536fe4eb791f");
     assert_eq!(root, expected_root);
@@ -88,7 +88,7 @@ fn test_containers_bits_struct_lengthy_0() {
 
 #[test]
 fn test_containers_bits_struct_lengthy_1() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([63]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
@@ -105,7 +105,7 @@ fn test_containers_bits_struct_lengthy_1() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xe60c419e4e47a1b6ef55da0450fdba5b8b6d9e8c8a1ddf913aad21c1faf6bb61");
     assert_eq!(root, expected_root);
@@ -113,7 +113,7 @@ fn test_containers_bits_struct_lengthy_1() {
 
 #[test]
 fn test_containers_bits_struct_lengthy_2() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([60]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
@@ -130,7 +130,7 @@ fn test_containers_bits_struct_lengthy_2() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x4a082a227bdfdf5f1b7ebd49d0d4cdf7e8408c789d3fb7c0fe864c76df8e24fc");
     assert_eq!(root, expected_root);
@@ -138,7 +138,7 @@ fn test_containers_bits_struct_lengthy_2() {
 
 #[test]
 fn test_containers_bits_struct_lengthy_3() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([50]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
@@ -154,7 +154,7 @@ fn test_containers_bits_struct_lengthy_3() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xd843398a3d7f8a24411eb830f22fac7c9717599712f914de6dac35eaccfdc1a7");
     assert_eq!(root, expected_root);
@@ -162,7 +162,7 @@ fn test_containers_bits_struct_lengthy_3() {
 
 #[test]
 fn test_containers_bits_struct_lengthy_4() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([47]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
@@ -178,7 +178,7 @@ fn test_containers_bits_struct_lengthy_4() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xa57212943eb47330d7a46286317233228ea24753830d7f535c9f3539da05c221");
     assert_eq!(root, expected_root);
@@ -186,7 +186,7 @@ fn test_containers_bits_struct_lengthy_4() {
 
 #[test]
 fn test_containers_bits_struct_lengthy_5() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([41]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
@@ -203,7 +203,7 @@ fn test_containers_bits_struct_lengthy_5() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x2f71110caf7d5cacae796b3ddeeb74b43390f33c06e1587b794b7872b5e6bbd9");
     assert_eq!(root, expected_root);
@@ -211,7 +211,7 @@ fn test_containers_bits_struct_lengthy_5() {
 
 #[test]
 fn test_containers_bits_struct_lengthy_6() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([52]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
@@ -227,7 +227,7 @@ fn test_containers_bits_struct_lengthy_6() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x1d2a640e0bd2c88f0e39fe04acac9ccab6023295f82442fbcb8f437cd5958928");
     assert_eq!(root, expected_root);
@@ -235,7 +235,7 @@ fn test_containers_bits_struct_lengthy_6() {
 
 #[test]
 fn test_containers_bits_struct_lengthy_7() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([53]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([3]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
@@ -251,7 +251,7 @@ fn test_containers_bits_struct_lengthy_7() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf1355a89ade8334350d4d958939abf8c912e13680583a94614f6f579fa7cf321");
     assert_eq!(root, expected_root);
@@ -259,7 +259,7 @@ fn test_containers_bits_struct_lengthy_7() {
 
 #[test]
 fn test_containers_bits_struct_lengthy_8() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([36]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
@@ -275,7 +275,7 @@ fn test_containers_bits_struct_lengthy_8() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x30c3e66f646c942bdcfcee75ac9df9ff077b4cf42a4e83036eab3f6694c0d9ef");
     assert_eq!(root, expected_root);
@@ -283,7 +283,7 @@ fn test_containers_bits_struct_lengthy_8() {
 
 #[test]
 fn test_containers_bits_struct_lengthy_9() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([61]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
@@ -300,7 +300,7 @@ fn test_containers_bits_struct_lengthy_9() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x180723e3b3e1cdc31c4273a035a3c6aa98429a81022a538eb11527500c3eed54");
     assert_eq!(root, expected_root);
@@ -308,7 +308,7 @@ fn test_containers_bits_struct_lengthy_9() {
 
 #[test]
 fn test_containers_bits_struct_lengthy_chaos_0() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([24]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([3]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
@@ -325,7 +325,7 @@ fn test_containers_bits_struct_lengthy_chaos_0() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xc519405516b452d688b17e71d666d289b3c869240fe80a0777f667079dcdd417");
     assert_eq!(root, expected_root);
@@ -333,7 +333,7 @@ fn test_containers_bits_struct_lengthy_chaos_0() {
 
 #[test]
 fn test_containers_bits_struct_lengthy_chaos_1() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([3]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([2]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
@@ -350,7 +350,7 @@ fn test_containers_bits_struct_lengthy_chaos_1() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x9d428532ee66fb4d06c44d1bbe7e8e7c833de8c5d7d6d21d8d0c4061e2b4fa98");
     assert_eq!(root, expected_root);
@@ -358,7 +358,7 @@ fn test_containers_bits_struct_lengthy_chaos_1() {
 
 #[test]
 fn test_containers_bits_struct_lengthy_chaos_2() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
@@ -374,7 +374,7 @@ fn test_containers_bits_struct_lengthy_chaos_2() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x1242c79e7318d2fe4313ee7c803fffeba9c536a176904ec947a6e4ff118c6e7a");
     assert_eq!(root, expected_root);
@@ -462,7 +462,7 @@ fn test_containers_bits_struct_lengthy_offset_6_zeroed() {
 
 #[test]
 fn test_containers_bits_struct_max() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([7]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([3]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
@@ -479,7 +479,7 @@ fn test_containers_bits_struct_max() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x190480a9dff580c6ae64dcf4906a5db90dfd45a2ad0baed4ad53995d1951fc81");
     assert_eq!(root, expected_root);
@@ -487,7 +487,7 @@ fn test_containers_bits_struct_max() {
 
 #[test]
 fn test_containers_bits_struct_max_0() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([31]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([3]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
@@ -504,7 +504,7 @@ fn test_containers_bits_struct_max_0() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xeae3e4f6352cba6d4f3177ba2b84c3a8a64cc32cd4ab95a3f9c803da92d10c73");
     assert_eq!(root, expected_root);
@@ -512,7 +512,7 @@ fn test_containers_bits_struct_max_0() {
 
 #[test]
 fn test_containers_bits_struct_max_1() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([63]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([3]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
@@ -529,7 +529,7 @@ fn test_containers_bits_struct_max_1() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x8b80e46316a0153807d81741e170b9b2c1c33a42ed143a5bd3fca75e248f8382");
     assert_eq!(root, expected_root);
@@ -537,7 +537,7 @@ fn test_containers_bits_struct_max_1() {
 
 #[test]
 fn test_containers_bits_struct_max_2() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([7]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([3]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
@@ -554,7 +554,7 @@ fn test_containers_bits_struct_max_2() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x190480a9dff580c6ae64dcf4906a5db90dfd45a2ad0baed4ad53995d1951fc81");
     assert_eq!(root, expected_root);
@@ -562,7 +562,7 @@ fn test_containers_bits_struct_max_2() {
 
 #[test]
 fn test_containers_bits_struct_max_3() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([15]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([3]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
@@ -579,7 +579,7 @@ fn test_containers_bits_struct_max_3() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x662a52b056d31844fe9a143bc7bf82f6c52d7cc9d6b9d9736c2e0d7c9a4b65f3");
     assert_eq!(root, expected_root);
@@ -587,7 +587,7 @@ fn test_containers_bits_struct_max_3() {
 
 #[test]
 fn test_containers_bits_struct_max_4() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([31]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([3]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
@@ -604,7 +604,7 @@ fn test_containers_bits_struct_max_4() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x9b86a73b16c1aabe418cf266c4ba7160bdd39881fa3f36196c0b8fd21c689236");
     assert_eq!(root, expected_root);
@@ -612,7 +612,7 @@ fn test_containers_bits_struct_max_4() {
 
 #[test]
 fn test_containers_bits_struct_max_5() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([3]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
@@ -629,7 +629,7 @@ fn test_containers_bits_struct_max_5() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xd075a5e28fe1a7cec77ef949d5cee0e5a49ce1f7ff024141635f9a057abb22b9");
     assert_eq!(root, expected_root);
@@ -637,7 +637,7 @@ fn test_containers_bits_struct_max_5() {
 
 #[test]
 fn test_containers_bits_struct_max_6() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([7]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([3]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
@@ -654,7 +654,7 @@ fn test_containers_bits_struct_max_6() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x190480a9dff580c6ae64dcf4906a5db90dfd45a2ad0baed4ad53995d1951fc81");
     assert_eq!(root, expected_root);
@@ -662,7 +662,7 @@ fn test_containers_bits_struct_max_6() {
 
 #[test]
 fn test_containers_bits_struct_max_7() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([7]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([3]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
@@ -679,7 +679,7 @@ fn test_containers_bits_struct_max_7() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x66f206fba60009ff2bcadce0380055d893d4eb154f13bbce8a1e88618ad17f7c");
     assert_eq!(root, expected_root);
@@ -687,7 +687,7 @@ fn test_containers_bits_struct_max_7() {
 
 #[test]
 fn test_containers_bits_struct_max_8() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([7]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([3]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
@@ -704,7 +704,7 @@ fn test_containers_bits_struct_max_8() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xad8ac96de2066eef5bcb859e32dbf4120dff7d64efd015629878c805d7d38a01");
     assert_eq!(root, expected_root);
@@ -712,7 +712,7 @@ fn test_containers_bits_struct_max_8() {
 
 #[test]
 fn test_containers_bits_struct_max_9() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([31]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([3]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
@@ -729,7 +729,7 @@ fn test_containers_bits_struct_max_9() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x40a1610ef58a700508f807372f97fe4f218b495f1b2dac7eb7e3473c08e12e8a");
     assert_eq!(root, expected_root);
@@ -737,7 +737,7 @@ fn test_containers_bits_struct_max_9() {
 
 #[test]
 fn test_containers_bits_struct_max_chaos_0() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([35]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([2]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
@@ -753,7 +753,7 @@ fn test_containers_bits_struct_max_chaos_0() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x4f2f961dd57ecda6054514babf40477a40ff8a1fa93181300d2c423202ed8c9c");
     assert_eq!(root, expected_root);
@@ -761,7 +761,7 @@ fn test_containers_bits_struct_max_chaos_0() {
 
 #[test]
 fn test_containers_bits_struct_max_chaos_1() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
@@ -777,7 +777,7 @@ fn test_containers_bits_struct_max_chaos_1() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x284a24c22e1267eaceb9a5ccc4a33b62be2214d29e4bcf51bb1ce3b814543751");
     assert_eq!(root, expected_root);
@@ -785,7 +785,7 @@ fn test_containers_bits_struct_max_chaos_1() {
 
 #[test]
 fn test_containers_bits_struct_max_chaos_2() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([2]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([3]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
@@ -801,7 +801,7 @@ fn test_containers_bits_struct_max_chaos_2() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x44c854217e658de6aadd600dd1d35b161c957258b52f1a714ab484899752ce17");
     assert_eq!(root, expected_root);
@@ -809,7 +809,7 @@ fn test_containers_bits_struct_max_chaos_2() {
 
 #[test]
 fn test_containers_bits_struct_nil_0() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
@@ -826,7 +826,7 @@ fn test_containers_bits_struct_nil_0() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x02cae738e3dc8b57f344ada4f509f2945e8264c80c3438eadaf7c02535f9e5ef");
     assert_eq!(root, expected_root);
@@ -834,7 +834,7 @@ fn test_containers_bits_struct_nil_0() {
 
 #[test]
 fn test_containers_bits_struct_nil_1() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([2]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
@@ -850,7 +850,7 @@ fn test_containers_bits_struct_nil_1() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xe82bc1a89606f63c4bdacbe443e271857c6d30b872266f9b27684779d96dae87");
     assert_eq!(root, expected_root);
@@ -858,7 +858,7 @@ fn test_containers_bits_struct_nil_1() {
 
 #[test]
 fn test_containers_bits_struct_nil_2() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
@@ -874,7 +874,7 @@ fn test_containers_bits_struct_nil_2() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xa980a92d284073c940c314a2e9e2c5ccbd4c38185095c01b625ddd74985b5100");
     assert_eq!(root, expected_root);
@@ -882,7 +882,7 @@ fn test_containers_bits_struct_nil_2() {
 
 #[test]
 fn test_containers_bits_struct_nil_3() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
@@ -898,7 +898,7 @@ fn test_containers_bits_struct_nil_3() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x26d7bf2aa63ea0083ab583c594d124e800fc6f2bddf60e421e8b19e9cce812c8");
     assert_eq!(root, expected_root);
@@ -906,7 +906,7 @@ fn test_containers_bits_struct_nil_3() {
 
 #[test]
 fn test_containers_bits_struct_nil_4() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([2]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
@@ -923,7 +923,7 @@ fn test_containers_bits_struct_nil_4() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0ba55be71b0c8aa27881aa7d980e2b48d14d613ee44de539507f146f7c6e0dd8");
     assert_eq!(root, expected_root);
@@ -931,7 +931,7 @@ fn test_containers_bits_struct_nil_4() {
 
 #[test]
 fn test_containers_bits_struct_nil_5() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
@@ -948,7 +948,7 @@ fn test_containers_bits_struct_nil_5() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xbe88737ecc160104b6d2b57424aeadc47a65e5fa0bb5bf78ddf4c2cf3430e1ac");
     assert_eq!(root, expected_root);
@@ -956,7 +956,7 @@ fn test_containers_bits_struct_nil_5() {
 
 #[test]
 fn test_containers_bits_struct_nil_6() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([3]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
@@ -972,7 +972,7 @@ fn test_containers_bits_struct_nil_6() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xbdbeec5011cc40b1917d0c7954acc5001525b78f91eccfddd9a25bda277301e8");
     assert_eq!(root, expected_root);
@@ -980,7 +980,7 @@ fn test_containers_bits_struct_nil_6() {
 
 #[test]
 fn test_containers_bits_struct_nil_7() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
@@ -997,7 +997,7 @@ fn test_containers_bits_struct_nil_7() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x2b87f84bf6446b279917684baa83c80f4fa8d689f62e145be8d712015a18a2d5");
     assert_eq!(root, expected_root);
@@ -1005,7 +1005,7 @@ fn test_containers_bits_struct_nil_7() {
 
 #[test]
 fn test_containers_bits_struct_nil_8() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([2]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
@@ -1022,7 +1022,7 @@ fn test_containers_bits_struct_nil_8() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xc1299667d3f14c145f16a59725a14f80ccec9a83e337111e3610778964134490");
     assert_eq!(root, expected_root);
@@ -1030,7 +1030,7 @@ fn test_containers_bits_struct_nil_8() {
 
 #[test]
 fn test_containers_bits_struct_nil_9() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
@@ -1047,7 +1047,7 @@ fn test_containers_bits_struct_nil_9() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x6ac1452c1f8cd1182acd576a5d19d6eb4dc2004f4bde3c6571876be6a0227702");
     assert_eq!(root, expected_root);
@@ -1055,7 +1055,7 @@ fn test_containers_bits_struct_nil_9() {
 
 #[test]
 fn test_containers_bits_struct_nil_chaos_0() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([3]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([3]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
@@ -1071,7 +1071,7 @@ fn test_containers_bits_struct_nil_chaos_0() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x60a456ab306a8e0f64432852dfc84c3dad3bd89cd7bbd579eab99cea81741f30");
     assert_eq!(root, expected_root);
@@ -1079,7 +1079,7 @@ fn test_containers_bits_struct_nil_chaos_0() {
 
 #[test]
 fn test_containers_bits_struct_nil_chaos_1() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([3]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
@@ -1095,7 +1095,7 @@ fn test_containers_bits_struct_nil_chaos_1() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x9d19b565eb266738667e6a8da2f208b1c7134a5b7c0567b667082a7590e9021a");
     assert_eq!(root, expected_root);
@@ -1103,7 +1103,7 @@ fn test_containers_bits_struct_nil_chaos_1() {
 
 #[test]
 fn test_containers_bits_struct_nil_chaos_2() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([41]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([3]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
@@ -1119,7 +1119,7 @@ fn test_containers_bits_struct_nil_chaos_2() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x1e26e04116dd161c893ae1113250ca48a28e7a022f55d52d1602ee435600e601");
     assert_eq!(root, expected_root);
@@ -1187,7 +1187,7 @@ fn test_containers_bits_struct_nil_offset_6_zeroed() {
 
 #[test]
 fn test_containers_bits_struct_one_0() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([3]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
@@ -1204,7 +1204,7 @@ fn test_containers_bits_struct_one_0() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x7fd438e3ac2c6ad689ef88c4438fea7d4ed8ea53ae0a245c57a8b52369959654");
     assert_eq!(root, expected_root);
@@ -1212,7 +1212,7 @@ fn test_containers_bits_struct_one_0() {
 
 #[test]
 fn test_containers_bits_struct_one_1() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([2]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([3]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
@@ -1229,7 +1229,7 @@ fn test_containers_bits_struct_one_1() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xce39647d9029abdc453ad6d6b247495fc23e5e82013ba821b120dabfab8fb537");
     assert_eq!(root, expected_root);
@@ -1237,7 +1237,7 @@ fn test_containers_bits_struct_one_1() {
 
 #[test]
 fn test_containers_bits_struct_one_2() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([3]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([3]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
@@ -1253,7 +1253,7 @@ fn test_containers_bits_struct_one_2() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x097a90072bcf49d920b02bcab4e1da31a077dcbee8bfce2966d7840c3022f838");
     assert_eq!(root, expected_root);
@@ -1261,7 +1261,7 @@ fn test_containers_bits_struct_one_2() {
 
 #[test]
 fn test_containers_bits_struct_one_3() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([2]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([3]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
@@ -1277,7 +1277,7 @@ fn test_containers_bits_struct_one_3() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x4d33c9a02ae2fa2d66880c086862b88e4300727de2ab8860e5599de3a7653c64");
     assert_eq!(root, expected_root);
@@ -1285,7 +1285,7 @@ fn test_containers_bits_struct_one_3() {
 
 #[test]
 fn test_containers_bits_struct_one_4() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([3]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([3]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
@@ -1302,7 +1302,7 @@ fn test_containers_bits_struct_one_4() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x3d2f26de96c8814d47d80494bad8a04cb958198a1a10950f19e2324d29e3a037");
     assert_eq!(root, expected_root);
@@ -1310,7 +1310,7 @@ fn test_containers_bits_struct_one_4() {
 
 #[test]
 fn test_containers_bits_struct_one_5() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([3]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
@@ -1327,7 +1327,7 @@ fn test_containers_bits_struct_one_5() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x02289430e9b794b65c6e1ac184209135a3ccb6c3b5e8b4fd2c3064fae138667d");
     assert_eq!(root, expected_root);
@@ -1335,7 +1335,7 @@ fn test_containers_bits_struct_one_5() {
 
 #[test]
 fn test_containers_bits_struct_one_6() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([3]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
@@ -1351,7 +1351,7 @@ fn test_containers_bits_struct_one_6() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x226c12e28fc1b8a77c3b19cf64436d3312a4437301fe83783b8be1840c1e8653");
     assert_eq!(root, expected_root);
@@ -1359,7 +1359,7 @@ fn test_containers_bits_struct_one_6() {
 
 #[test]
 fn test_containers_bits_struct_one_7() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([3]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
@@ -1376,7 +1376,7 @@ fn test_containers_bits_struct_one_7() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x6f276c9d37fdb7089835b85c261c14d75b198c06c2eb819dd71643f4589f7d18");
     assert_eq!(root, expected_root);
@@ -1384,7 +1384,7 @@ fn test_containers_bits_struct_one_7() {
 
 #[test]
 fn test_containers_bits_struct_one_8() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([3]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([2]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
@@ -1401,7 +1401,7 @@ fn test_containers_bits_struct_one_8() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x74f7aac312d88b6652023e15626bfd39184bd672f1fa3d79884b6decc800fb4d");
     assert_eq!(root, expected_root);
@@ -1409,7 +1409,7 @@ fn test_containers_bits_struct_one_8() {
 
 #[test]
 fn test_containers_bits_struct_one_9() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([2]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
@@ -1425,7 +1425,7 @@ fn test_containers_bits_struct_one_9() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x7cab55ba2fd53be0f8a4f8c4251b7c0a5ef803d7823412898d665823abfbc306");
     assert_eq!(root, expected_root);
@@ -1433,7 +1433,7 @@ fn test_containers_bits_struct_one_9() {
 
 #[test]
 fn test_containers_bits_struct_one_chaos_0() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
@@ -1450,7 +1450,7 @@ fn test_containers_bits_struct_one_chaos_0() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xff3ba06886f4ad196c05211f6e949d9308d3c6db2387b26d43ca0e8c5e9046b1");
     assert_eq!(root, expected_root);
@@ -1458,7 +1458,7 @@ fn test_containers_bits_struct_one_chaos_0() {
 
 #[test]
 fn test_containers_bits_struct_one_chaos_1() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([42]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([3]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
@@ -1475,7 +1475,7 @@ fn test_containers_bits_struct_one_chaos_1() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x10f2e40368c4ddd6e2bbfc642ba10f92d87e1e163b5c3c6cecc6f4f2fce4af11");
     assert_eq!(root, expected_root);
@@ -1483,7 +1483,7 @@ fn test_containers_bits_struct_one_chaos_1() {
 
 #[test]
 fn test_containers_bits_struct_one_chaos_2() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([3]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
@@ -1500,7 +1500,7 @@ fn test_containers_bits_struct_one_chaos_2() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x643306351ddbcaa2e885e08cc0a794491f5a7802d4ed29026b508d0446ded10a");
     assert_eq!(root, expected_root);
@@ -1592,7 +1592,7 @@ fn test_containers_bits_struct_one_offset_6_zeroed() {
 
 #[test]
 fn test_containers_bits_struct_random_0() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([3]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
@@ -1609,7 +1609,7 @@ fn test_containers_bits_struct_random_0() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x3d6d0bb8bf83015e09b309485d2e76fab9218bbf6c3a9e7c69cfe542ad1dc763");
     assert_eq!(root, expected_root);
@@ -1617,7 +1617,7 @@ fn test_containers_bits_struct_random_0() {
 
 #[test]
 fn test_containers_bits_struct_random_1() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([42]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
@@ -1634,7 +1634,7 @@ fn test_containers_bits_struct_random_1() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x15d9164c4e094b4403feb31122f3b66b7ca7822e4df67f26def12cc8215eb841");
     assert_eq!(root, expected_root);
@@ -1642,7 +1642,7 @@ fn test_containers_bits_struct_random_1() {
 
 #[test]
 fn test_containers_bits_struct_random_2() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([11]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([2]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
@@ -1659,7 +1659,7 @@ fn test_containers_bits_struct_random_2() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xecba0d802886089cf592e9fc1618eba10423632ccb4ee47861ef967a46cb0128");
     assert_eq!(root, expected_root);
@@ -1667,7 +1667,7 @@ fn test_containers_bits_struct_random_2() {
 
 #[test]
 fn test_containers_bits_struct_random_3() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([27]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([2]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
@@ -1684,7 +1684,7 @@ fn test_containers_bits_struct_random_3() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x51edea0f4034e4367f17128b2ca93ce6d640ca7d0cbd5441115e0a88f3570286");
     assert_eq!(root, expected_root);
@@ -1692,7 +1692,7 @@ fn test_containers_bits_struct_random_3() {
 
 #[test]
 fn test_containers_bits_struct_random_4() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([27]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
@@ -1709,7 +1709,7 @@ fn test_containers_bits_struct_random_4() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x755039126524a09294e1127ef05e4d63ef1d24b08697ef1b8492264b397c23ca");
     assert_eq!(root, expected_root);
@@ -1717,7 +1717,7 @@ fn test_containers_bits_struct_random_4() {
 
 #[test]
 fn test_containers_bits_struct_random_5() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([2]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
@@ -1734,7 +1734,7 @@ fn test_containers_bits_struct_random_5() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x3febb22617b99d80ea55324e92473257af007edd898977edbaf18b292e9883ab");
     assert_eq!(root, expected_root);
@@ -1742,7 +1742,7 @@ fn test_containers_bits_struct_random_5() {
 
 #[test]
 fn test_containers_bits_struct_random_6() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([14]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
@@ -1759,7 +1759,7 @@ fn test_containers_bits_struct_random_6() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x56a559c34fc3c84452dfa273cbf2e6e59d07475374a37caeee6a33e5172842b0");
     assert_eq!(root, expected_root);
@@ -1767,7 +1767,7 @@ fn test_containers_bits_struct_random_6() {
 
 #[test]
 fn test_containers_bits_struct_random_7() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([2]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
@@ -1783,7 +1783,7 @@ fn test_containers_bits_struct_random_7() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x13ec3bf0b472b0e516f29b26ea2cd1b2df5339f4523b13aa382467a227ce9630");
     assert_eq!(root, expected_root);
@@ -1791,7 +1791,7 @@ fn test_containers_bits_struct_random_7() {
 
 #[test]
 fn test_containers_bits_struct_random_8() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([59]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
@@ -1808,7 +1808,7 @@ fn test_containers_bits_struct_random_8() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x7cac78985bce1d521c85c04de9131c25c520f41e4e8199a1d29531f8e1770049");
     assert_eq!(root, expected_root);
@@ -1816,7 +1816,7 @@ fn test_containers_bits_struct_random_8() {
 
 #[test]
 fn test_containers_bits_struct_random_9() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([4]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
@@ -1832,7 +1832,7 @@ fn test_containers_bits_struct_random_9() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x79724705ac18d0920f81f87f6f727d38ce5c83253a5391151efba7664f6a5695");
     assert_eq!(root, expected_root);
@@ -1840,7 +1840,7 @@ fn test_containers_bits_struct_random_9() {
 
 #[test]
 fn test_containers_bits_struct_random_chaos_0() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([11]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([2]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
@@ -1857,7 +1857,7 @@ fn test_containers_bits_struct_random_chaos_0() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x95854efa0f0935a1a80eefdd467742fd57bcba65b702cafe6ae1486054da4577");
     assert_eq!(root, expected_root);
@@ -1865,7 +1865,7 @@ fn test_containers_bits_struct_random_chaos_0() {
 
 #[test]
 fn test_containers_bits_struct_random_chaos_1() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([9]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([3]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
@@ -1882,7 +1882,7 @@ fn test_containers_bits_struct_random_chaos_1() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x62a43ebc4181c5be74e81c7d524e8d0a73c0c824b997c1788cdeb0d502b6a56e");
     assert_eq!(root, expected_root);
@@ -1890,7 +1890,7 @@ fn test_containers_bits_struct_random_chaos_1() {
 
 #[test]
 fn test_containers_bits_struct_random_chaos_2() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([61]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
@@ -1907,7 +1907,7 @@ fn test_containers_bits_struct_random_chaos_2() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x9b213c958d8c67fbee3c40ce85f14eb32efbe45919b9374844a878cd37ddc531");
     assert_eq!(root, expected_root);
@@ -1971,7 +1971,7 @@ fn test_containers_bits_struct_random_offset_6_zeroed() {
 
 #[test]
 fn test_containers_bits_struct_zero() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
@@ -1987,7 +1987,7 @@ fn test_containers_bits_struct_zero() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x434f7fd5c6afb75027d4220d1638330a7db1e338e3926862797e2b3dc06df758");
     assert_eq!(root, expected_root);
@@ -1995,7 +1995,7 @@ fn test_containers_bits_struct_zero() {
 
 #[test]
 fn test_containers_bits_struct_zero_0() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([2]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
@@ -2011,7 +2011,7 @@ fn test_containers_bits_struct_zero_0() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xde86acdbf24592cddb2b2c46ae0a7a8df2500ff298ebb7991d3ba9b1004aa3a7");
     assert_eq!(root, expected_root);
@@ -2019,7 +2019,7 @@ fn test_containers_bits_struct_zero_0() {
 
 #[test]
 fn test_containers_bits_struct_zero_1() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
@@ -2035,7 +2035,7 @@ fn test_containers_bits_struct_zero_1() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x23ef8cd72a9fc4008bd066d5ff490fa88b67da044916c18c08f2a932c974f981");
     assert_eq!(root, expected_root);
@@ -2043,7 +2043,7 @@ fn test_containers_bits_struct_zero_1() {
 
 #[test]
 fn test_containers_bits_struct_zero_2() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
@@ -2059,7 +2059,7 @@ fn test_containers_bits_struct_zero_2() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x23ef8cd72a9fc4008bd066d5ff490fa88b67da044916c18c08f2a932c974f981");
     assert_eq!(root, expected_root);
@@ -2067,7 +2067,7 @@ fn test_containers_bits_struct_zero_2() {
 
 #[test]
 fn test_containers_bits_struct_zero_3() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
@@ -2083,7 +2083,7 @@ fn test_containers_bits_struct_zero_3() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xa08e590982dffd5e3b7a9410c9d86d152cfb2d342bd00eec228aab3e3c5ef64b");
     assert_eq!(root, expected_root);
@@ -2091,7 +2091,7 @@ fn test_containers_bits_struct_zero_3() {
 
 #[test]
 fn test_containers_bits_struct_zero_4() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([32]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
@@ -2107,7 +2107,7 @@ fn test_containers_bits_struct_zero_4() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x9e0668c44cbaefb38cebe11f091d66fa6b78c970bbefe5b1e9d6412adae30179");
     assert_eq!(root, expected_root);
@@ -2115,7 +2115,7 @@ fn test_containers_bits_struct_zero_4() {
 
 #[test]
 fn test_containers_bits_struct_zero_5() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([16]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
@@ -2131,7 +2131,7 @@ fn test_containers_bits_struct_zero_5() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x7aa68d25017352ef95142af2bb269ce805269676da6111d74887aa9cdcb072a4");
     assert_eq!(root, expected_root);
@@ -2139,7 +2139,7 @@ fn test_containers_bits_struct_zero_5() {
 
 #[test]
 fn test_containers_bits_struct_zero_6() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([32]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
@@ -2155,7 +2155,7 @@ fn test_containers_bits_struct_zero_6() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xe7767ef6cf38ec10994866c9dbfc2263fdbae71ab5b70728fbe184f7714511bd");
     assert_eq!(root, expected_root);
@@ -2163,7 +2163,7 @@ fn test_containers_bits_struct_zero_6() {
 
 #[test]
 fn test_containers_bits_struct_zero_7() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([32]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
@@ -2179,7 +2179,7 @@ fn test_containers_bits_struct_zero_7() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x9e0668c44cbaefb38cebe11f091d66fa6b78c970bbefe5b1e9d6412adae30179");
     assert_eq!(root, expected_root);
@@ -2187,7 +2187,7 @@ fn test_containers_bits_struct_zero_7() {
 
 #[test]
 fn test_containers_bits_struct_zero_8() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([8]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
@@ -2203,7 +2203,7 @@ fn test_containers_bits_struct_zero_8() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x7ae92ab3514825eced5b012a3506efa5034df961f432552a898b3f13cad1d064");
     assert_eq!(root, expected_root);
@@ -2211,7 +2211,7 @@ fn test_containers_bits_struct_zero_8() {
 
 #[test]
 fn test_containers_bits_struct_zero_9() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([4]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([0]).as_ref()).unwrap(),
@@ -2227,7 +2227,7 @@ fn test_containers_bits_struct_zero_9() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xa7c8f2f9944d28e0554028670f6c36c9887e8d3bcbe583e1fbef3c5ca2071f34");
     assert_eq!(root, expected_root);
@@ -2235,7 +2235,7 @@ fn test_containers_bits_struct_zero_9() {
 
 #[test]
 fn test_containers_bits_struct_zero_chaos_0() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([3]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
@@ -2251,7 +2251,7 @@ fn test_containers_bits_struct_zero_chaos_0() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xb1eb7e2c64e6ce5bc27ee4f1a03ed21dcc80eff8981e3397dd81316778cec97c");
     assert_eq!(root, expected_root);
@@ -2259,7 +2259,7 @@ fn test_containers_bits_struct_zero_chaos_0() {
 
 #[test]
 fn test_containers_bits_struct_zero_chaos_1() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
@@ -2276,7 +2276,7 @@ fn test_containers_bits_struct_zero_chaos_1() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xdbec2b84815a9559d7a268df030674d92da93d7ba62d356542f09f721b928a97");
     assert_eq!(root, expected_root);
@@ -2284,7 +2284,7 @@ fn test_containers_bits_struct_zero_chaos_1() {
 
 #[test]
 fn test_containers_bits_struct_zero_chaos_2() {
-    let mut value = BitsStruct {
+    let value = BitsStruct {
         a: <Bitlist<5> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
         b: <Bitvector<2> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([3]).as_ref()).unwrap(),
         c: <Bitvector<1> as TryFrom<&[u8]>>::try_from(Vec::<u8>::from_iter([1]).as_ref()).unwrap(),
@@ -2301,7 +2301,7 @@ fn test_containers_bits_struct_zero_chaos_2() {
     let recovered_value: BitsStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf523978784972b9399337193a286299df5ef1559f4d336b4d1859331cc1fa99b");
     assert_eq!(root, expected_root);
@@ -2319,7 +2319,7 @@ fn test_containers_complex_test_struct_extra_byte() {
 
 #[test]
 fn test_containers_complex_test_struct_lengthy_0() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 5717,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([
             235, 64949, 43916, 37422, 6559, 2732, 61895, 2418, 64448, 36828, 54582, 10602, 58840,
@@ -2664,7 +2664,7 @@ fn test_containers_complex_test_struct_lengthy_0() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x409c14e61e36bf8db6c0a273f5fca52280863df38f70c876ba562c01533cba17");
     assert_eq!(root, expected_root);
@@ -2672,7 +2672,7 @@ fn test_containers_complex_test_struct_lengthy_0() {
 
 #[test]
 fn test_containers_complex_test_struct_lengthy_1() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 55607,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([
             62505, 41292, 62622, 63875, 25101, 7094, 43058, 29347, 7897, 45444, 63411, 49477,
@@ -3017,7 +3017,7 @@ fn test_containers_complex_test_struct_lengthy_1() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xa4207e21d4f48b20a17aae0219bd46da1eb9b13485685656fe109d55cd369ac8");
     assert_eq!(root, expected_root);
@@ -3025,7 +3025,7 @@ fn test_containers_complex_test_struct_lengthy_1() {
 
 #[test]
 fn test_containers_complex_test_struct_lengthy_2() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 32608,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([
             55350, 21656, 57724, 51795, 3930, 4048, 47282, 29956, 20641, 44773, 60183, 30145,
@@ -3371,7 +3371,7 @@ fn test_containers_complex_test_struct_lengthy_2() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf41cc77c30f0cd5add63388b749139c9df6fcb8ff2806512e79d98466ba1fa41");
     assert_eq!(root, expected_root);
@@ -3379,7 +3379,7 @@ fn test_containers_complex_test_struct_lengthy_2() {
 
 #[test]
 fn test_containers_complex_test_struct_lengthy_3() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 22118,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([
             34158, 709, 41595, 32315, 36989, 37132, 49334, 7713, 10602, 52865, 45676, 59352, 54292,
@@ -3724,7 +3724,7 @@ fn test_containers_complex_test_struct_lengthy_3() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x31fc8b3bb311ac99f398eb8b474bd4ddc903588f3c654bba01758d752bcbacad");
     assert_eq!(root, expected_root);
@@ -3732,7 +3732,7 @@ fn test_containers_complex_test_struct_lengthy_3() {
 
 #[test]
 fn test_containers_complex_test_struct_lengthy_4() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 53065,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([
             8619, 43550, 7933, 30929, 42442, 12522, 32152, 1808, 32026, 6854, 46390, 64625, 65295,
@@ -4078,7 +4078,7 @@ fn test_containers_complex_test_struct_lengthy_4() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x3ad83cce6644031d6c4b7a69eea5a1cd13e8912a746e706a02ef08843dc043ee");
     assert_eq!(root, expected_root);
@@ -4086,7 +4086,7 @@ fn test_containers_complex_test_struct_lengthy_4() {
 
 #[test]
 fn test_containers_complex_test_struct_lengthy_5() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 18122,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([
             20954, 38379, 3749, 18564, 6778, 35025, 27343, 44320, 35889, 56845, 60482, 53328,
@@ -4433,7 +4433,7 @@ fn test_containers_complex_test_struct_lengthy_5() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0b01c7ef4ea7cfde110e2926c6bcde2dc49be76c35702768fc6328265296577d");
     assert_eq!(root, expected_root);
@@ -4441,7 +4441,7 @@ fn test_containers_complex_test_struct_lengthy_5() {
 
 #[test]
 fn test_containers_complex_test_struct_lengthy_6() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 61904,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([
             48367, 44269, 5739, 44814, 9723, 33067, 30071, 58706, 9435, 23016, 21381, 43658, 53430,
@@ -4786,7 +4786,7 @@ fn test_containers_complex_test_struct_lengthy_6() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x87a78833e8bbf97b366cec1dfdea6afe7db2f45ddbebe89e530a61ee30916317");
     assert_eq!(root, expected_root);
@@ -4794,7 +4794,7 @@ fn test_containers_complex_test_struct_lengthy_6() {
 
 #[test]
 fn test_containers_complex_test_struct_lengthy_7() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 7107,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([
             28503, 63450, 61337, 26522, 10224, 44515, 40100, 46378, 44123, 49466, 14003, 27129,
@@ -5140,7 +5140,7 @@ fn test_containers_complex_test_struct_lengthy_7() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x1e7461b40d33feff5e512edc9beed8bf33a7a5594423c131897f12e0e5ec37d2");
     assert_eq!(root, expected_root);
@@ -5148,7 +5148,7 @@ fn test_containers_complex_test_struct_lengthy_7() {
 
 #[test]
 fn test_containers_complex_test_struct_lengthy_8() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 22011,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([
             7085, 55600, 36311, 62044, 16166, 44872, 42545, 27688, 20688, 59144, 7216, 58148,
@@ -5495,7 +5495,7 @@ fn test_containers_complex_test_struct_lengthy_8() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x5a922b2dc965a5c310302bb0706dccd63445e59234cdc203412fcd48517c5567");
     assert_eq!(root, expected_root);
@@ -5503,7 +5503,7 @@ fn test_containers_complex_test_struct_lengthy_8() {
 
 #[test]
 fn test_containers_complex_test_struct_lengthy_9() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 56435,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([
             3952, 290, 251, 58961, 30325, 51905, 50433, 13351, 17042, 42136, 54586, 6638, 17986,
@@ -5848,7 +5848,7 @@ fn test_containers_complex_test_struct_lengthy_9() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x18714348fd9390ada358e4a2c28b5c5f89e697a7e3d1e72945c8a5d51a63eddb");
     assert_eq!(root, expected_root);
@@ -5856,7 +5856,7 @@ fn test_containers_complex_test_struct_lengthy_9() {
 
 #[test]
 fn test_containers_complex_test_struct_lengthy_chaos_0() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 0,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([
             0, 22202, 27857, 0, 42502, 17093, 55470, 38783, 0, 20844, 61541, 24724, 65535, 26906,
@@ -6112,7 +6112,7 @@ fn test_containers_complex_test_struct_lengthy_chaos_0() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xe44dd00cd673ec9a1ac4c4c809b2dc4a709e6c606045d3098bb6b6daff757086");
     assert_eq!(root, expected_root);
@@ -6120,7 +6120,7 @@ fn test_containers_complex_test_struct_lengthy_chaos_0() {
 
 #[test]
 fn test_containers_complex_test_struct_lengthy_chaos_1() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 23928,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([
             29889, 65535, 6919, 17783, 48165, 15126, 7391, 38239, 63793, 21029, 0, 12957, 0, 65535,
@@ -6258,7 +6258,7 @@ fn test_containers_complex_test_struct_lengthy_chaos_1() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf55c38f28e2305a905c22ee6a1bc0001216ec753835851e48b8f4adf0607ff2a");
     assert_eq!(root, expected_root);
@@ -6266,7 +6266,7 @@ fn test_containers_complex_test_struct_lengthy_chaos_1() {
 
 #[test]
 fn test_containers_complex_test_struct_lengthy_chaos_2() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 0,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([
             64091, 22003, 13074, 45519, 65535, 52650, 31421, 12635, 9020, 17970, 32335, 29377,
@@ -6373,7 +6373,7 @@ fn test_containers_complex_test_struct_lengthy_chaos_2() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x2188f5a9533d6ac453782f96a17aa100bcd8847755b95fc6a1cff5313b696357");
     assert_eq!(root, expected_root);
@@ -6461,7 +6461,7 @@ fn test_containers_complex_test_struct_lengthy_offset_7_zeroed() {
 
 #[test]
 fn test_containers_complex_test_struct_max() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 65535,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([
             65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
@@ -6560,7 +6560,7 @@ fn test_containers_complex_test_struct_max() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x88848f1694182d82948d7d61dd420638ced418fbd7b0d599a5006133e5f275e6");
     assert_eq!(root, expected_root);
@@ -6568,7 +6568,7 @@ fn test_containers_complex_test_struct_max() {
 
 #[test]
 fn test_containers_complex_test_struct_max_0() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 65535,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([
             65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
@@ -6782,7 +6782,7 @@ fn test_containers_complex_test_struct_max_0() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x49523d3cfe6d9486ae984e3ed16997da67d623cb9d91a7ddf79474273557c278");
     assert_eq!(root, expected_root);
@@ -6790,7 +6790,7 @@ fn test_containers_complex_test_struct_max_0() {
 
 #[test]
 fn test_containers_complex_test_struct_max_1() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 65535,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([
             65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
@@ -6936,7 +6936,7 @@ fn test_containers_complex_test_struct_max_1() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x851e0a459531f06bce0ae644ff2beec71f59bde9272bb0608d3d81e4be6c7b79");
     assert_eq!(root, expected_root);
@@ -6944,7 +6944,7 @@ fn test_containers_complex_test_struct_max_1() {
 
 #[test]
 fn test_containers_complex_test_struct_max_2() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 65535,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([
             65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
@@ -7078,7 +7078,7 @@ fn test_containers_complex_test_struct_max_2() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x89ef01b048542f12299fc4c7c1ca891c52d451e65e1cecb6eea027d0879a437b");
     assert_eq!(root, expected_root);
@@ -7086,7 +7086,7 @@ fn test_containers_complex_test_struct_max_2() {
 
 #[test]
 fn test_containers_complex_test_struct_max_3() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 65535,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([
             65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
@@ -7235,7 +7235,7 @@ fn test_containers_complex_test_struct_max_3() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x895ae3955634ee47df5502b910cc7eb4ce1638e8b6ed2d394f3d102ad15f7fbc");
     assert_eq!(root, expected_root);
@@ -7243,7 +7243,7 @@ fn test_containers_complex_test_struct_max_3() {
 
 #[test]
 fn test_containers_complex_test_struct_max_4() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 65535,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([
             65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
@@ -7339,7 +7339,7 @@ fn test_containers_complex_test_struct_max_4() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x2764a7c55d05740396bcaa0aaad1c79ee51e6e0f00d857c6ef00adbc925359eb");
     assert_eq!(root, expected_root);
@@ -7347,7 +7347,7 @@ fn test_containers_complex_test_struct_max_4() {
 
 #[test]
 fn test_containers_complex_test_struct_max_5() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 65535,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([
             65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
@@ -7582,7 +7582,7 @@ fn test_containers_complex_test_struct_max_5() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xcb22d4bcd66eee249a2fa9880a5014688bffb619d1a1d0cece0958fdc6ef67a0");
     assert_eq!(root, expected_root);
@@ -7590,7 +7590,7 @@ fn test_containers_complex_test_struct_max_5() {
 
 #[test]
 fn test_containers_complex_test_struct_max_6() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 65535,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([
             65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
@@ -7770,7 +7770,7 @@ fn test_containers_complex_test_struct_max_6() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x98176543e9f5948bfcce73bfc90b0487cf2feba17c54f123a0186278585d2255");
     assert_eq!(root, expected_root);
@@ -7778,7 +7778,7 @@ fn test_containers_complex_test_struct_max_6() {
 
 #[test]
 fn test_containers_complex_test_struct_max_7() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 65535,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([
             65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
@@ -8018,7 +8018,7 @@ fn test_containers_complex_test_struct_max_7() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x86e208bf04cbe646770f39838f02ff47d77c3eecd6416a15c963200090343ce6");
     assert_eq!(root, expected_root);
@@ -8026,7 +8026,7 @@ fn test_containers_complex_test_struct_max_7() {
 
 #[test]
 fn test_containers_complex_test_struct_max_8() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 65535,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([
             65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
@@ -8221,7 +8221,7 @@ fn test_containers_complex_test_struct_max_8() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xfc3e2fdcfc18a9a1a2939ab101ea90d5822364e8169f74ac41563bde13f77dde");
     assert_eq!(root, expected_root);
@@ -8229,7 +8229,7 @@ fn test_containers_complex_test_struct_max_8() {
 
 #[test]
 fn test_containers_complex_test_struct_max_9() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 65535,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([
             65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
@@ -8384,7 +8384,7 @@ fn test_containers_complex_test_struct_max_9() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x3df75b0d07a91733fa91042699b686dd7f871b3bc647bd282e11b83d7b8bad4e");
     assert_eq!(root, expected_root);
@@ -8392,7 +8392,7 @@ fn test_containers_complex_test_struct_max_9() {
 
 #[test]
 fn test_containers_complex_test_struct_max_chaos_0() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 65535,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([
             33548, 65535, 27252, 30260, 7129, 50745, 46575, 65535, 14243, 49842, 12278, 16138,
@@ -8620,7 +8620,7 @@ fn test_containers_complex_test_struct_max_chaos_0() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x7830b5fabc26bdb3f55dfaf8111fe4790a4320c3444bca8c38d1b8ac253f684e");
     assert_eq!(root, expected_root);
@@ -8628,7 +8628,7 @@ fn test_containers_complex_test_struct_max_chaos_0() {
 
 #[test]
 fn test_containers_complex_test_struct_max_chaos_1() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 65535,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([
             23886, 48569, 0, 50118, 65535, 32879, 65535, 44111, 18232, 51122, 65535, 62233, 20445,
@@ -8857,7 +8857,7 @@ fn test_containers_complex_test_struct_max_chaos_1() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xe18df8aacc7cb9e900244c003b5850297314c74f42b7b7faf3451c33c97a8d38");
     assert_eq!(root, expected_root);
@@ -8865,7 +8865,7 @@ fn test_containers_complex_test_struct_max_chaos_1() {
 
 #[test]
 fn test_containers_complex_test_struct_max_chaos_2() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 65535,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([
             0, 65535, 54084, 16256, 34273, 65535, 65535, 48971, 65535, 60519, 65535, 19583, 62612,
@@ -9005,7 +9005,7 @@ fn test_containers_complex_test_struct_max_chaos_2() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x83f81e711657e10a505159f722c03e2a4388b20ebda4210094cd8aba93f53d5d");
     assert_eq!(root, expected_root);
@@ -9013,7 +9013,7 @@ fn test_containers_complex_test_struct_max_chaos_2() {
 
 #[test]
 fn test_containers_complex_test_struct_nil_0() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 19485,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([])).unwrap(),
         c: 180,
@@ -9053,7 +9053,7 @@ fn test_containers_complex_test_struct_nil_0() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x05bb1882d46575e2bc5dc7148051bf464e4df6f271a31321001e857c7895bacf");
     assert_eq!(root, expected_root);
@@ -9061,7 +9061,7 @@ fn test_containers_complex_test_struct_nil_0() {
 
 #[test]
 fn test_containers_complex_test_struct_nil_1() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 31862,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([])).unwrap(),
         c: 130,
@@ -9101,7 +9101,7 @@ fn test_containers_complex_test_struct_nil_1() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x58ee3514728894b03c5099a22a571ecd725755466df364bf7a57e7b28a3a5a0d");
     assert_eq!(root, expected_root);
@@ -9109,7 +9109,7 @@ fn test_containers_complex_test_struct_nil_1() {
 
 #[test]
 fn test_containers_complex_test_struct_nil_2() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 23196,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([])).unwrap(),
         c: 113,
@@ -9149,7 +9149,7 @@ fn test_containers_complex_test_struct_nil_2() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x200f6d4be8b29aa0f833d63639119d08eae8acacc527047690318e25819d7239");
     assert_eq!(root, expected_root);
@@ -9157,7 +9157,7 @@ fn test_containers_complex_test_struct_nil_2() {
 
 #[test]
 fn test_containers_complex_test_struct_nil_3() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 60841,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([])).unwrap(),
         c: 187,
@@ -9197,7 +9197,7 @@ fn test_containers_complex_test_struct_nil_3() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x620f18ab8fddf91e5207f8887d9761be6fb672c4a57d01fa4962604c4d812fad");
     assert_eq!(root, expected_root);
@@ -9205,7 +9205,7 @@ fn test_containers_complex_test_struct_nil_3() {
 
 #[test]
 fn test_containers_complex_test_struct_nil_4() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 21814,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([])).unwrap(),
         c: 4,
@@ -9245,7 +9245,7 @@ fn test_containers_complex_test_struct_nil_4() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xc75a13f8ba4d56d78324313bc49f15de88dc7b23c8a19b96bde8092a9bb70b83");
     assert_eq!(root, expected_root);
@@ -9253,7 +9253,7 @@ fn test_containers_complex_test_struct_nil_4() {
 
 #[test]
 fn test_containers_complex_test_struct_nil_5() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 25053,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([])).unwrap(),
         c: 58,
@@ -9293,7 +9293,7 @@ fn test_containers_complex_test_struct_nil_5() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x6ef0e14dc6f46f40c86d65c94c29afa89f2dde63f2b2931e64bf820900b0755d");
     assert_eq!(root, expected_root);
@@ -9301,7 +9301,7 @@ fn test_containers_complex_test_struct_nil_5() {
 
 #[test]
 fn test_containers_complex_test_struct_nil_6() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 49427,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([])).unwrap(),
         c: 38,
@@ -9341,7 +9341,7 @@ fn test_containers_complex_test_struct_nil_6() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0b1c17953fafada3820c7a59db020154d0f5f1d4b06b772c4db16230c9d77a9d");
     assert_eq!(root, expected_root);
@@ -9349,7 +9349,7 @@ fn test_containers_complex_test_struct_nil_6() {
 
 #[test]
 fn test_containers_complex_test_struct_nil_7() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 3985,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([])).unwrap(),
         c: 215,
@@ -9389,7 +9389,7 @@ fn test_containers_complex_test_struct_nil_7() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x9b967a5a3ba0e36a9e065908ea5aed331d03f8f17228ec7583071c4fd7a279ff");
     assert_eq!(root, expected_root);
@@ -9397,7 +9397,7 @@ fn test_containers_complex_test_struct_nil_7() {
 
 #[test]
 fn test_containers_complex_test_struct_nil_8() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 9027,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([])).unwrap(),
         c: 140,
@@ -9437,7 +9437,7 @@ fn test_containers_complex_test_struct_nil_8() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xae34c46e97a3d2c4a6ad6782a17cce892f912deb9e27f8342c076e463a4ab1af");
     assert_eq!(root, expected_root);
@@ -9445,7 +9445,7 @@ fn test_containers_complex_test_struct_nil_8() {
 
 #[test]
 fn test_containers_complex_test_struct_nil_9() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 38573,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([])).unwrap(),
         c: 146,
@@ -9485,7 +9485,7 @@ fn test_containers_complex_test_struct_nil_9() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x052e5374ba3620756ed73b79878607555e407a7393515f1aeea3da9f2ec252a8");
     assert_eq!(root, expected_root);
@@ -9493,7 +9493,7 @@ fn test_containers_complex_test_struct_nil_9() {
 
 #[test]
 fn test_containers_complex_test_struct_nil_chaos_0() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 31237,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([
             65535, 2814, 48248, 28900, 0, 0, 58773, 65535, 55881, 54469, 57296, 51980, 35061,
@@ -9646,7 +9646,7 @@ fn test_containers_complex_test_struct_nil_chaos_0() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x663ac96094d20fa3ee53493a634653172d3864513da3f38d14d2a4429ed4bbd3");
     assert_eq!(root, expected_root);
@@ -9654,7 +9654,7 @@ fn test_containers_complex_test_struct_nil_chaos_0() {
 
 #[test]
 fn test_containers_complex_test_struct_nil_chaos_1() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 64128,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([
             0, 65472, 14705, 36376, 65535, 56894, 26486, 4406, 0, 25544, 65535, 65535, 29047, 0, 0,
@@ -9809,7 +9809,7 @@ fn test_containers_complex_test_struct_nil_chaos_1() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x1de2e6e269b79034e9e81aba443f9e2e8c0c66e49ffb49c3dea82ce5a0788398");
     assert_eq!(root, expected_root);
@@ -9817,7 +9817,7 @@ fn test_containers_complex_test_struct_nil_chaos_1() {
 
 #[test]
 fn test_containers_complex_test_struct_nil_chaos_2() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 19852,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([])).unwrap(),
         c: 142,
@@ -9896,7 +9896,7 @@ fn test_containers_complex_test_struct_nil_chaos_2() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x43c51c1784a07f7eb57f8ae5dfe7a4ec37c7a086101f331b753bf1117fd7236b");
     assert_eq!(root, expected_root);
@@ -9960,7 +9960,7 @@ fn test_containers_complex_test_struct_nil_offset_7_zeroed() {
 
 #[test]
 fn test_containers_complex_test_struct_one_0() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 38154,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([47908])).unwrap(),
         c: 143,
@@ -10000,7 +10000,7 @@ fn test_containers_complex_test_struct_one_0() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xff0954642b226bd43a9e5039d29f93ac8b691cc448bbf4eb2dfe4d189da9cbed");
     assert_eq!(root, expected_root);
@@ -10008,7 +10008,7 @@ fn test_containers_complex_test_struct_one_0() {
 
 #[test]
 fn test_containers_complex_test_struct_one_1() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 13143,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([8619])).unwrap(),
         c: 204,
@@ -10048,7 +10048,7 @@ fn test_containers_complex_test_struct_one_1() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x30585fde416d36ce2d348b70297cd7fd09c4551b0dd1deee62d41aedfb95af0e");
     assert_eq!(root, expected_root);
@@ -10056,7 +10056,7 @@ fn test_containers_complex_test_struct_one_1() {
 
 #[test]
 fn test_containers_complex_test_struct_one_2() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 2132,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([12333])).unwrap(),
         c: 91,
@@ -10096,7 +10096,7 @@ fn test_containers_complex_test_struct_one_2() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xc9437ccf57457f4cbe655692eba592369aa3db85848d6aadf306ce972f5491e0");
     assert_eq!(root, expected_root);
@@ -10104,7 +10104,7 @@ fn test_containers_complex_test_struct_one_2() {
 
 #[test]
 fn test_containers_complex_test_struct_one_3() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 36438,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([6183])).unwrap(),
         c: 56,
@@ -10144,7 +10144,7 @@ fn test_containers_complex_test_struct_one_3() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x7aa69f757591d6ea01a99f7e924d78fdc082e32ca8f07c00a8a183d76bfe1c61");
     assert_eq!(root, expected_root);
@@ -10152,7 +10152,7 @@ fn test_containers_complex_test_struct_one_3() {
 
 #[test]
 fn test_containers_complex_test_struct_one_4() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 7019,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([21115])).unwrap(),
         c: 38,
@@ -10192,7 +10192,7 @@ fn test_containers_complex_test_struct_one_4() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x233b24ab7e5f473361ee2bda67221aa64da667b1d130f48673fe642fe3fc393d");
     assert_eq!(root, expected_root);
@@ -10200,7 +10200,7 @@ fn test_containers_complex_test_struct_one_4() {
 
 #[test]
 fn test_containers_complex_test_struct_one_5() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 42404,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([27499])).unwrap(),
         c: 129,
@@ -10240,7 +10240,7 @@ fn test_containers_complex_test_struct_one_5() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x13abc7a3790c13f6ef94157a97d1b90d1c05d488fb40a9a1fda9e8d5c8cc01b1");
     assert_eq!(root, expected_root);
@@ -10248,7 +10248,7 @@ fn test_containers_complex_test_struct_one_5() {
 
 #[test]
 fn test_containers_complex_test_struct_one_6() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 6760,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([53019])).unwrap(),
         c: 203,
@@ -10288,7 +10288,7 @@ fn test_containers_complex_test_struct_one_6() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x2eb015bc47b6979baaf4f6b282f88e9ae9fe0c42d119e3adbfeea304f59c9adb");
     assert_eq!(root, expected_root);
@@ -10296,7 +10296,7 @@ fn test_containers_complex_test_struct_one_6() {
 
 #[test]
 fn test_containers_complex_test_struct_one_7() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 27051,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([41373])).unwrap(),
         c: 93,
@@ -10336,7 +10336,7 @@ fn test_containers_complex_test_struct_one_7() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xa5942e18cbc2c03264bfc0cc69e29e13f134c95495103c2b3466df20c75ef1e7");
     assert_eq!(root, expected_root);
@@ -10344,7 +10344,7 @@ fn test_containers_complex_test_struct_one_7() {
 
 #[test]
 fn test_containers_complex_test_struct_one_8() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 25971,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([20564])).unwrap(),
         c: 187,
@@ -10384,7 +10384,7 @@ fn test_containers_complex_test_struct_one_8() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x7a8efffdb7f5d3439511ce3561de603f5045de609f2b32f18fd3f047679f9904");
     assert_eq!(root, expected_root);
@@ -10392,7 +10392,7 @@ fn test_containers_complex_test_struct_one_8() {
 
 #[test]
 fn test_containers_complex_test_struct_one_9() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 21941,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([36043])).unwrap(),
         c: 128,
@@ -10432,7 +10432,7 @@ fn test_containers_complex_test_struct_one_9() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x6e7ac8728198a06e6edf766748f545ad7a70867b8bc834415f88167f19933eb6");
     assert_eq!(root, expected_root);
@@ -10440,7 +10440,7 @@ fn test_containers_complex_test_struct_one_9() {
 
 #[test]
 fn test_containers_complex_test_struct_one_chaos_0() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 15280,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([])).unwrap(),
         c: 255,
@@ -10723,7 +10723,7 @@ fn test_containers_complex_test_struct_one_chaos_0() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x4c0a5c0335b803a36ad2e8ae8063eaa7420c091797074082bf0113df9a941df2");
     assert_eq!(root, expected_root);
@@ -10731,7 +10731,7 @@ fn test_containers_complex_test_struct_one_chaos_0() {
 
 #[test]
 fn test_containers_complex_test_struct_one_chaos_1() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 34335,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([
             28911, 23128, 5142, 39460, 28794, 0, 45973, 0, 65535, 14654, 0, 20168, 44845, 65535,
@@ -10778,7 +10778,7 @@ fn test_containers_complex_test_struct_one_chaos_1() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xd9c780f1cc4ba0f9f4c121062c817a6b74825de8e4d374a7b17f11ecea73cb3b");
     assert_eq!(root, expected_root);
@@ -10786,7 +10786,7 @@ fn test_containers_complex_test_struct_one_chaos_1() {
 
 #[test]
 fn test_containers_complex_test_struct_one_chaos_2() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 6168,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([
             23271, 13490, 0, 0, 8475, 6430, 29468, 65535, 8198, 65535, 3774, 22672, 38858, 4157,
@@ -11002,7 +11002,7 @@ fn test_containers_complex_test_struct_one_chaos_2() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf2662f0b6e96aa420aa3eef028c170264009f6768273afd0646de22f0873d033");
     assert_eq!(root, expected_root);
@@ -11090,7 +11090,7 @@ fn test_containers_complex_test_struct_one_offset_7_zeroed() {
 
 #[test]
 fn test_containers_complex_test_struct_random_0() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 36613,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([
             26357, 19789, 53414, 41528, 43058, 36456, 17712, 64993, 14992, 3994, 4491, 37237,
@@ -11272,7 +11272,7 @@ fn test_containers_complex_test_struct_random_0() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x1677290a19a687395e9912e9b41e5e3b4ea7e0db5daf8417ae531552e3f6395d");
     assert_eq!(root, expected_root);
@@ -11280,7 +11280,7 @@ fn test_containers_complex_test_struct_random_0() {
 
 #[test]
 fn test_containers_complex_test_struct_random_1() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 5814,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([
             13962, 12707, 37305, 29690, 1586, 45727, 61950, 20772, 19719, 25719, 17231, 18362,
@@ -11501,7 +11501,7 @@ fn test_containers_complex_test_struct_random_1() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xe32e03a987cb2baeadbc01e090ddf3d00edcffd93f93812fb192524585345e06");
     assert_eq!(root, expected_root);
@@ -11509,7 +11509,7 @@ fn test_containers_complex_test_struct_random_1() {
 
 #[test]
 fn test_containers_complex_test_struct_random_2() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 30472,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([
             49312, 29633, 44804, 1208, 59965, 7626, 18533, 16651, 61231, 26530, 6559, 46253, 3629,
@@ -11763,7 +11763,7 @@ fn test_containers_complex_test_struct_random_2() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x80f233ed450b080e645437eb00253f9000760d4e37788026fd7948b7329ade91");
     assert_eq!(root, expected_root);
@@ -11771,7 +11771,7 @@ fn test_containers_complex_test_struct_random_2() {
 
 #[test]
 fn test_containers_complex_test_struct_random_3() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 51614,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([
             53782, 28969, 18301, 63374, 56984, 55478, 16687,
@@ -12001,7 +12001,7 @@ fn test_containers_complex_test_struct_random_3() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x8fc069cc0b3cf9d3b5a2ba1ed9668ceb7538a3814b045b6743a861a69c65ef58");
     assert_eq!(root, expected_root);
@@ -12009,7 +12009,7 @@ fn test_containers_complex_test_struct_random_3() {
 
 #[test]
 fn test_containers_complex_test_struct_random_4() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 46515,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([
             19362, 29937, 37197, 17341, 19247, 46329, 65029, 59777, 12984, 1102, 20472, 52710,
@@ -12160,7 +12160,7 @@ fn test_containers_complex_test_struct_random_4() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x2ea25cba8117cccb157ba87fae135ce7c9664164e9dcd6ef18bb0bac068b2d4a");
     assert_eq!(root, expected_root);
@@ -12168,7 +12168,7 @@ fn test_containers_complex_test_struct_random_4() {
 
 #[test]
 fn test_containers_complex_test_struct_random_5() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 23283,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([
             18483, 29026, 38069, 48164, 17418, 12521, 41392, 25184, 18692, 37690, 63055, 14440,
@@ -12371,7 +12371,7 @@ fn test_containers_complex_test_struct_random_5() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xfd4e05bd4a5888d4313babf3e7ce4b74c7660cdec611af2ccdd5f1d65a13d761");
     assert_eq!(root, expected_root);
@@ -12379,7 +12379,7 @@ fn test_containers_complex_test_struct_random_5() {
 
 #[test]
 fn test_containers_complex_test_struct_random_6() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 32343,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([
             13118, 45070, 36699, 34426, 53562, 47965, 49426, 8279, 16168, 5347, 61069, 52341,
@@ -12535,7 +12535,7 @@ fn test_containers_complex_test_struct_random_6() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xbd149483bde62bcbc37fad5a43ea14579623cec6435387a0578d19bbb3f08503");
     assert_eq!(root, expected_root);
@@ -12543,7 +12543,7 @@ fn test_containers_complex_test_struct_random_6() {
 
 #[test]
 fn test_containers_complex_test_struct_random_7() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 53455,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([
             28472, 20013, 10186, 52619, 37505, 32299, 35612, 7194, 25051, 43900, 20431, 58627,
@@ -12822,7 +12822,7 @@ fn test_containers_complex_test_struct_random_7() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x774e0245882bec129d09f588f961cf712bde706bc4f255b228551eed4879879a");
     assert_eq!(root, expected_root);
@@ -12830,7 +12830,7 @@ fn test_containers_complex_test_struct_random_7() {
 
 #[test]
 fn test_containers_complex_test_struct_random_8() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 2705,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([34403, 7858, 29371, 4245])).unwrap(),
         c: 5,
@@ -13000,7 +13000,7 @@ fn test_containers_complex_test_struct_random_8() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xe5956b72a5b8403ed677d979cf840a28ec09ed55bb80ce0feaf4fec3049ef40a");
     assert_eq!(root, expected_root);
@@ -13008,7 +13008,7 @@ fn test_containers_complex_test_struct_random_8() {
 
 #[test]
 fn test_containers_complex_test_struct_random_9() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 47426,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([
             19759, 24984, 33337, 36131, 45227, 54145, 47460, 60807, 15609, 5357, 23158, 749, 55515,
@@ -13273,7 +13273,7 @@ fn test_containers_complex_test_struct_random_9() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x9054f3149ce6b8079f9bf1b858a8937ff85bb645a70f1b592195f37c33013990");
     assert_eq!(root, expected_root);
@@ -13281,7 +13281,7 @@ fn test_containers_complex_test_struct_random_9() {
 
 #[test]
 fn test_containers_complex_test_struct_random_chaos_0() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 65535,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([
             0, 53109, 16152, 8907, 43706, 12557, 29217, 0, 65535, 65535, 53745, 0, 44917, 0, 41205,
@@ -13393,7 +13393,7 @@ fn test_containers_complex_test_struct_random_chaos_0() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xae1e922e817ee774556b4db803a022256303c5976fb7877838d68a303ab639a6");
     assert_eq!(root, expected_root);
@@ -13401,7 +13401,7 @@ fn test_containers_complex_test_struct_random_chaos_0() {
 
 #[test]
 fn test_containers_complex_test_struct_random_chaos_1() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 65535,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([25564, 22479, 0])).unwrap(),
         c: 198,
@@ -13551,7 +13551,7 @@ fn test_containers_complex_test_struct_random_chaos_1() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x00fa804cb785eb45fdd8d96b6466f613e0d0e5a2c0d3b2d0a568b162c9ceea63");
     assert_eq!(root, expected_root);
@@ -13559,7 +13559,7 @@ fn test_containers_complex_test_struct_random_chaos_1() {
 
 #[test]
 fn test_containers_complex_test_struct_random_chaos_2() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 0,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([
             54727, 11819, 50263, 46482, 54220, 42693, 0, 22107, 11129, 65535, 16209, 46452, 65535,
@@ -13680,7 +13680,7 @@ fn test_containers_complex_test_struct_random_chaos_2() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5c310453f8053e0cacc58bb955684048cf2879354b546433592a8fc6e84ef28");
     assert_eq!(root, expected_root);
@@ -13744,7 +13744,7 @@ fn test_containers_complex_test_struct_random_offset_7_zeroed() {
 
 #[test]
 fn test_containers_complex_test_struct_zero() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 0,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -13872,7 +13872,7 @@ fn test_containers_complex_test_struct_zero() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xfa353b25483c1bce7a459da360aef0bf390398ff94040fc368ca0656dd36cafd");
     assert_eq!(root, expected_root);
@@ -13880,7 +13880,7 @@ fn test_containers_complex_test_struct_zero() {
 
 #[test]
 fn test_containers_complex_test_struct_zero_0() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 0,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -14000,7 +14000,7 @@ fn test_containers_complex_test_struct_zero_0() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x796da05fdc213f44fba67f9c4c113d647a86f70a58950461b7326b411b94eb6d");
     assert_eq!(root, expected_root);
@@ -14008,7 +14008,7 @@ fn test_containers_complex_test_struct_zero_0() {
 
 #[test]
 fn test_containers_complex_test_struct_zero_1() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 0,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]))
             .unwrap(),
@@ -14119,7 +14119,7 @@ fn test_containers_complex_test_struct_zero_1() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x8738293bf20a8e620887aec3956815d54d8ef18feb18756c8cb60236ee972c98");
     assert_eq!(root, expected_root);
@@ -14127,7 +14127,7 @@ fn test_containers_complex_test_struct_zero_1() {
 
 #[test]
 fn test_containers_complex_test_struct_zero_2() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 0,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -14255,7 +14255,7 @@ fn test_containers_complex_test_struct_zero_2() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x09c0008b8fb65319fe8e5db9e0334cf57328793c9e36a7dd4638de677f40392c");
     assert_eq!(root, expected_root);
@@ -14263,7 +14263,7 @@ fn test_containers_complex_test_struct_zero_2() {
 
 #[test]
 fn test_containers_complex_test_struct_zero_3() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 0,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -14377,7 +14377,7 @@ fn test_containers_complex_test_struct_zero_3() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xe545099c564f5331c87e9b4805760b5a212ce9e552e0c4ac4ab1288c185907ca");
     assert_eq!(root, expected_root);
@@ -14385,7 +14385,7 @@ fn test_containers_complex_test_struct_zero_3() {
 
 #[test]
 fn test_containers_complex_test_struct_zero_4() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 0,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -14503,7 +14503,7 @@ fn test_containers_complex_test_struct_zero_4() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x2278700f1c8b6bacee1aeb99204b47d3e12939b88c75534e07595e236be676c3");
     assert_eq!(root, expected_root);
@@ -14511,7 +14511,7 @@ fn test_containers_complex_test_struct_zero_4() {
 
 #[test]
 fn test_containers_complex_test_struct_zero_5() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 0,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -14615,7 +14615,7 @@ fn test_containers_complex_test_struct_zero_5() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xaa57bdc7c1f1c3582329bcfe7e14331b4ebe8396a4539d450d8df2e489783190");
     assert_eq!(root, expected_root);
@@ -14623,7 +14623,7 @@ fn test_containers_complex_test_struct_zero_5() {
 
 #[test]
 fn test_containers_complex_test_struct_zero_6() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 0,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -14753,7 +14753,7 @@ fn test_containers_complex_test_struct_zero_6() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xd0682307761ba3cd546856f9b77594c4fa2e831b2ca74863d7cde954cb2e2ea4");
     assert_eq!(root, expected_root);
@@ -14761,7 +14761,7 @@ fn test_containers_complex_test_struct_zero_6() {
 
 #[test]
 fn test_containers_complex_test_struct_zero_7() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 0,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -14883,7 +14883,7 @@ fn test_containers_complex_test_struct_zero_7() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xcfde5a1ae1dc38d662d2f34b99c9ac9c36897a12c9aaff1c35ec577d834bf16b");
     assert_eq!(root, expected_root);
@@ -14891,7 +14891,7 @@ fn test_containers_complex_test_struct_zero_7() {
 
 #[test]
 fn test_containers_complex_test_struct_zero_8() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 0,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -14991,7 +14991,7 @@ fn test_containers_complex_test_struct_zero_8() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x587e3644da523a49b282fb076f22a8ba61ae675e7e0427ec9d88e3d20265cf7b");
     assert_eq!(root, expected_root);
@@ -14999,7 +14999,7 @@ fn test_containers_complex_test_struct_zero_8() {
 
 #[test]
 fn test_containers_complex_test_struct_zero_9() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 0,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -15119,7 +15119,7 @@ fn test_containers_complex_test_struct_zero_9() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x26490ddf2bdc78df57dae1cef92531f24edc013c4fbce99fff734aca1820828a");
     assert_eq!(root, expected_root);
@@ -15127,7 +15127,7 @@ fn test_containers_complex_test_struct_zero_9() {
 
 #[test]
 fn test_containers_complex_test_struct_zero_chaos_0() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 65535,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([])).unwrap(),
         c: 224,
@@ -15167,7 +15167,7 @@ fn test_containers_complex_test_struct_zero_chaos_0() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x436e534d95a1a12bf97c5d140c8e03399f62fe64a8335d828e17fa2769ba0ea6");
     assert_eq!(root, expected_root);
@@ -15175,7 +15175,7 @@ fn test_containers_complex_test_struct_zero_chaos_0() {
 
 #[test]
 fn test_containers_complex_test_struct_zero_chaos_1() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 0,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([
             8564, 58231, 65535, 0, 0, 24610, 65535, 63219, 28771, 0, 42839, 0, 0, 58799, 0, 0,
@@ -15337,7 +15337,7 @@ fn test_containers_complex_test_struct_zero_chaos_1() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xc8146e52b0d514f7e8597da0e6a2dd87cc5a7f7a66804b8b95f1d4ab456cf1a3");
     assert_eq!(root, expected_root);
@@ -15345,7 +15345,7 @@ fn test_containers_complex_test_struct_zero_chaos_1() {
 
 #[test]
 fn test_containers_complex_test_struct_zero_chaos_2() {
-    let mut value = ComplexTestStruct {
+    let value = ComplexTestStruct {
         a: 34579,
         b: List::<u16, 128>::try_from(Vec::<u16>::from_iter([50087])).unwrap(),
         c: 255,
@@ -15421,7 +15421,7 @@ fn test_containers_complex_test_struct_zero_chaos_2() {
     let recovered_value: ComplexTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x4a54450bf13e580af032198c139336321ed5fe021a9d7abc32fd8c5516d0dfc7");
     assert_eq!(root, expected_root);
@@ -15439,7 +15439,7 @@ fn test_containers_fixed_test_struct_extra_byte() {
 
 #[test]
 fn test_containers_fixed_test_struct_max() {
-    let mut value = FixedTestStruct { a: 255, b: 18446744073709551615, c: 4294967295 };
+    let value = FixedTestStruct { a: 255, b: 18446744073709551615, c: 4294967295 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/containers/valid/FixedTestStruct_max/serialized.ssz_snappy",
@@ -15449,7 +15449,7 @@ fn test_containers_fixed_test_struct_max() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x3925681862db7892428eac4afae08671930e623601b5b85fbbc366371e29acd7");
     assert_eq!(root, expected_root);
@@ -15457,7 +15457,7 @@ fn test_containers_fixed_test_struct_max() {
 
 #[test]
 fn test_containers_fixed_test_struct_max_chaos_0() {
-    let mut value = FixedTestStruct { a: 0, b: 16368780024300315290, c: 3425460342 };
+    let value = FixedTestStruct { a: 0, b: 16368780024300315290, c: 3425460342 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/containers/valid/FixedTestStruct_max_chaos_0/serialized.ssz_snappy",
@@ -15467,7 +15467,7 @@ fn test_containers_fixed_test_struct_max_chaos_0() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf9da7cee7f59d318ddece7744f9d57038776dcd2cb84ec1487df7810ab855eb8");
     assert_eq!(root, expected_root);
@@ -15475,7 +15475,7 @@ fn test_containers_fixed_test_struct_max_chaos_0() {
 
 #[test]
 fn test_containers_fixed_test_struct_max_chaos_1() {
-    let mut value = FixedTestStruct { a: 215, b: 0, c: 872994431 };
+    let value = FixedTestStruct { a: 215, b: 0, c: 872994431 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/containers/valid/FixedTestStruct_max_chaos_1/serialized.ssz_snappy",
@@ -15485,7 +15485,7 @@ fn test_containers_fixed_test_struct_max_chaos_1() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x775dcfb6a6f9ca7b3cc6e1a705c6892d46f88448ff5a32a139e17d5147c35f20");
     assert_eq!(root, expected_root);
@@ -15493,7 +15493,7 @@ fn test_containers_fixed_test_struct_max_chaos_1() {
 
 #[test]
 fn test_containers_fixed_test_struct_max_chaos_2() {
-    let mut value = FixedTestStruct { a: 255, b: 6156748712181862619, c: 0 };
+    let value = FixedTestStruct { a: 255, b: 6156748712181862619, c: 0 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/containers/valid/FixedTestStruct_max_chaos_2/serialized.ssz_snappy",
@@ -15503,7 +15503,7 @@ fn test_containers_fixed_test_struct_max_chaos_2() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xa2302ab770b50379d8a20013864f1ce653d180241a54a23e57413cb63b63148b");
     assert_eq!(root, expected_root);
@@ -15511,7 +15511,7 @@ fn test_containers_fixed_test_struct_max_chaos_2() {
 
 #[test]
 fn test_containers_fixed_test_struct_random_0() {
-    let mut value = FixedTestStruct { a: 24, b: 13167263067087249200, c: 734541227 };
+    let value = FixedTestStruct { a: 24, b: 13167263067087249200, c: 734541227 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/containers/valid/FixedTestStruct_random_0/serialized.ssz_snappy",
@@ -15521,7 +15521,7 @@ fn test_containers_fixed_test_struct_random_0() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x2f104507507c20439914e44dbbc82ab18c9c506cadbe96c33b136f3a4ff0f182");
     assert_eq!(root, expected_root);
@@ -15529,7 +15529,7 @@ fn test_containers_fixed_test_struct_random_0() {
 
 #[test]
 fn test_containers_fixed_test_struct_random_1() {
-    let mut value = FixedTestStruct { a: 31, b: 736233927488800041, c: 1393334686 };
+    let value = FixedTestStruct { a: 31, b: 736233927488800041, c: 1393334686 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/containers/valid/FixedTestStruct_random_1/serialized.ssz_snappy",
@@ -15539,7 +15539,7 @@ fn test_containers_fixed_test_struct_random_1() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf157cd7285b6607caac863911709648c432059be3cc3ccd7e7efbbd0abdf2cb0");
     assert_eq!(root, expected_root);
@@ -15547,7 +15547,7 @@ fn test_containers_fixed_test_struct_random_1() {
 
 #[test]
 fn test_containers_fixed_test_struct_random_2() {
-    let mut value = FixedTestStruct { a: 195, b: 16990693813108383139, c: 1812634554 };
+    let value = FixedTestStruct { a: 195, b: 16990693813108383139, c: 1812634554 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/containers/valid/FixedTestStruct_random_2/serialized.ssz_snappy",
@@ -15557,7 +15557,7 @@ fn test_containers_fixed_test_struct_random_2() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xadcb9275cf22b9fbe5a8ef1372336712f9402e335e3b4e085400955909f5b463");
     assert_eq!(root, expected_root);
@@ -15565,7 +15565,7 @@ fn test_containers_fixed_test_struct_random_2() {
 
 #[test]
 fn test_containers_fixed_test_struct_random_3() {
-    let mut value = FixedTestStruct { a: 77, b: 9825468808305409092, c: 3282831501 };
+    let value = FixedTestStruct { a: 77, b: 9825468808305409092, c: 3282831501 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/containers/valid/FixedTestStruct_random_3/serialized.ssz_snappy",
@@ -15575,7 +15575,7 @@ fn test_containers_fixed_test_struct_random_3() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xa31d9957f3f5c3f46bbc9916d92ac481f13a9d86df14c5960ea82d05c4930bfc");
     assert_eq!(root, expected_root);
@@ -15583,7 +15583,7 @@ fn test_containers_fixed_test_struct_random_3() {
 
 #[test]
 fn test_containers_fixed_test_struct_random_4() {
-    let mut value = FixedTestStruct { a: 142, b: 12943316248327749193, c: 1177791689 };
+    let value = FixedTestStruct { a: 142, b: 12943316248327749193, c: 1177791689 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/containers/valid/FixedTestStruct_random_4/serialized.ssz_snappy",
@@ -15593,7 +15593,7 @@ fn test_containers_fixed_test_struct_random_4() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x37bb39a61e6a896157c3f9b750ae496f07ea4746c88f8125d2ce0b71b379b26c");
     assert_eq!(root, expected_root);
@@ -15601,7 +15601,7 @@ fn test_containers_fixed_test_struct_random_4() {
 
 #[test]
 fn test_containers_fixed_test_struct_random_5() {
-    let mut value = FixedTestStruct { a: 152, b: 968434759530807861, c: 1892169706 };
+    let value = FixedTestStruct { a: 152, b: 968434759530807861, c: 1892169706 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/containers/valid/FixedTestStruct_random_5/serialized.ssz_snappy",
@@ -15611,7 +15611,7 @@ fn test_containers_fixed_test_struct_random_5() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x4048d84fe07daa71c9275b17f8766ee911c7b5b15f72156a12e8eb7bf73bd112");
     assert_eq!(root, expected_root);
@@ -15619,7 +15619,7 @@ fn test_containers_fixed_test_struct_random_5() {
 
 #[test]
 fn test_containers_fixed_test_struct_random_6() {
-    let mut value = FixedTestStruct { a: 251, b: 7019754704604394785, c: 10515695 };
+    let value = FixedTestStruct { a: 251, b: 7019754704604394785, c: 10515695 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/containers/valid/FixedTestStruct_random_6/serialized.ssz_snappy",
@@ -15629,7 +15629,7 @@ fn test_containers_fixed_test_struct_random_6() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xed6fdab725487c5048cca3ddd3cc337d0b6a180c1d5207cf95d7f5dd6cef97b5");
     assert_eq!(root, expected_root);
@@ -15637,7 +15637,7 @@ fn test_containers_fixed_test_struct_random_6() {
 
 #[test]
 fn test_containers_fixed_test_struct_random_7() {
-    let mut value = FixedTestStruct { a: 245, b: 5504897097224035493, c: 3554733444 };
+    let value = FixedTestStruct { a: 245, b: 5504897097224035493, c: 3554733444 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/containers/valid/FixedTestStruct_random_7/serialized.ssz_snappy",
@@ -15647,7 +15647,7 @@ fn test_containers_fixed_test_struct_random_7() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x91acafb600aa939a37f345ef75dee1a0ac48593f5a884827a22db67cc9cba8e7");
     assert_eq!(root, expected_root);
@@ -15655,7 +15655,7 @@ fn test_containers_fixed_test_struct_random_7() {
 
 #[test]
 fn test_containers_fixed_test_struct_random_8() {
-    let mut value = FixedTestStruct { a: 95, b: 11592110677720298001, c: 675128003 };
+    let value = FixedTestStruct { a: 95, b: 11592110677720298001, c: 675128003 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/containers/valid/FixedTestStruct_random_8/serialized.ssz_snappy",
@@ -15665,7 +15665,7 @@ fn test_containers_fixed_test_struct_random_8() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x393d6ba272e0211a0ea3e5d0abcf00a85a2d4680f804d0aee43205fb64d322b9");
     assert_eq!(root, expected_root);
@@ -15673,7 +15673,7 @@ fn test_containers_fixed_test_struct_random_8() {
 
 #[test]
 fn test_containers_fixed_test_struct_random_9() {
-    let mut value = FixedTestStruct { a: 189, b: 11077154515319582367, c: 885055256 };
+    let value = FixedTestStruct { a: 189, b: 11077154515319582367, c: 885055256 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/containers/valid/FixedTestStruct_random_9/serialized.ssz_snappy",
@@ -15683,7 +15683,7 @@ fn test_containers_fixed_test_struct_random_9() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xc2db52e4b936b48ac2b1762a5de13ece767c2358bcf8388d7f3bd588a8bcddf0");
     assert_eq!(root, expected_root);
@@ -15691,7 +15691,7 @@ fn test_containers_fixed_test_struct_random_9() {
 
 #[test]
 fn test_containers_fixed_test_struct_random_chaos_0() {
-    let mut value = FixedTestStruct { a: 224, b: 18446744073709551615, c: 4294967295 };
+    let value = FixedTestStruct { a: 224, b: 18446744073709551615, c: 4294967295 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/containers/valid/FixedTestStruct_random_chaos_0/serialized.ssz_snappy",
@@ -15701,7 +15701,7 @@ fn test_containers_fixed_test_struct_random_chaos_0() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x60c749becbd41b9c2cc1c45d9a3248248a359bbd3b51a63073a637f69078c87f");
     assert_eq!(root, expected_root);
@@ -15709,7 +15709,7 @@ fn test_containers_fixed_test_struct_random_chaos_0() {
 
 #[test]
 fn test_containers_fixed_test_struct_random_chaos_1() {
-    let mut value = FixedTestStruct { a: 0, b: 14186696757779471686, c: 3610222285 };
+    let value = FixedTestStruct { a: 0, b: 14186696757779471686, c: 3610222285 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/containers/valid/FixedTestStruct_random_chaos_1/serialized.ssz_snappy",
@@ -15719,7 +15719,7 @@ fn test_containers_fixed_test_struct_random_chaos_1() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x353a7d181607e8a955687d78b0d6e8905276b7746885b0760caae95a51579518");
     assert_eq!(root, expected_root);
@@ -15727,7 +15727,7 @@ fn test_containers_fixed_test_struct_random_chaos_1() {
 
 #[test]
 fn test_containers_fixed_test_struct_random_chaos_2() {
-    let mut value = FixedTestStruct { a: 130, b: 6370563341294793538, c: 4137753490 };
+    let value = FixedTestStruct { a: 130, b: 6370563341294793538, c: 4137753490 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/containers/valid/FixedTestStruct_random_chaos_2/serialized.ssz_snappy",
@@ -15737,7 +15737,7 @@ fn test_containers_fixed_test_struct_random_chaos_2() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x031b378c61c08633e1e99c601fdb3d899cc7f1c50c65ec8183e9caa958dadf43");
     assert_eq!(root, expected_root);
@@ -15745,7 +15745,7 @@ fn test_containers_fixed_test_struct_random_chaos_2() {
 
 #[test]
 fn test_containers_fixed_test_struct_zero() {
-    let mut value = FixedTestStruct { a: 0, b: 0, c: 0 };
+    let value = FixedTestStruct { a: 0, b: 0, c: 0 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/containers/valid/FixedTestStruct_zero/serialized.ssz_snappy",
@@ -15755,7 +15755,7 @@ fn test_containers_fixed_test_struct_zero() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xdb56114e00fdd4c1f85c892bf35ac9a89289aaecb1ebd0a96cde606a748b5d71");
     assert_eq!(root, expected_root);
@@ -15763,7 +15763,7 @@ fn test_containers_fixed_test_struct_zero() {
 
 #[test]
 fn test_containers_fixed_test_struct_zero_chaos_0() {
-    let mut value = FixedTestStruct { a: 255, b: 0, c: 3380095576 };
+    let value = FixedTestStruct { a: 255, b: 0, c: 3380095576 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/containers/valid/FixedTestStruct_zero_chaos_0/serialized.ssz_snappy",
@@ -15773,7 +15773,7 @@ fn test_containers_fixed_test_struct_zero_chaos_0() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xb7cf66c7aea564846607c9ecdcd467300442e1020ef59dcf2d2e988afb75c0b8");
     assert_eq!(root, expected_root);
@@ -15781,7 +15781,7 @@ fn test_containers_fixed_test_struct_zero_chaos_0() {
 
 #[test]
 fn test_containers_fixed_test_struct_zero_chaos_1() {
-    let mut value = FixedTestStruct { a: 40, b: 14820154409811446657, c: 0 };
+    let value = FixedTestStruct { a: 40, b: 14820154409811446657, c: 0 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/containers/valid/FixedTestStruct_zero_chaos_1/serialized.ssz_snappy",
@@ -15791,7 +15791,7 @@ fn test_containers_fixed_test_struct_zero_chaos_1() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0bef8d07795e1cb94eccc23fc5e0de20f96f777123ec914dc476513b74ce986b");
     assert_eq!(root, expected_root);
@@ -15799,7 +15799,7 @@ fn test_containers_fixed_test_struct_zero_chaos_1() {
 
 #[test]
 fn test_containers_fixed_test_struct_zero_chaos_2() {
-    let mut value = FixedTestStruct { a: 162, b: 18446744073709551615, c: 867140057 };
+    let value = FixedTestStruct { a: 162, b: 18446744073709551615, c: 867140057 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/containers/valid/FixedTestStruct_zero_chaos_2/serialized.ssz_snappy",
@@ -15809,7 +15809,7 @@ fn test_containers_fixed_test_struct_zero_chaos_2() {
     let recovered_value: FixedTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x9e79f87f5b034ada5f987f76e441790a13ead694ddd2d904170b6d6a93a9399d");
     assert_eq!(root, expected_root);
@@ -15825,7 +15825,7 @@ fn test_containers_single_field_test_struct_extra_byte() {
 
 #[test]
 fn test_containers_single_field_test_struct_max() {
-    let mut value = SingleFieldTestStruct { a: 255 };
+    let value = SingleFieldTestStruct { a: 255 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/containers/valid/SingleFieldTestStruct_max/serialized.ssz_snappy",
@@ -15835,7 +15835,7 @@ fn test_containers_single_field_test_struct_max() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xff00000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -15843,7 +15843,7 @@ fn test_containers_single_field_test_struct_max() {
 
 #[test]
 fn test_containers_single_field_test_struct_max_chaos_0() {
-    let mut value = SingleFieldTestStruct { a: 247 };
+    let value = SingleFieldTestStruct { a: 247 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data("ssz-rs/tests/data/containers/valid/SingleFieldTestStruct_max_chaos_0/serialized.ssz_snappy");
     assert_eq!(encoding, expected_encoding);
@@ -15851,7 +15851,7 @@ fn test_containers_single_field_test_struct_max_chaos_0() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf700000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -15859,7 +15859,7 @@ fn test_containers_single_field_test_struct_max_chaos_0() {
 
 #[test]
 fn test_containers_single_field_test_struct_max_chaos_1() {
-    let mut value = SingleFieldTestStruct { a: 76 };
+    let value = SingleFieldTestStruct { a: 76 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data("ssz-rs/tests/data/containers/valid/SingleFieldTestStruct_max_chaos_1/serialized.ssz_snappy");
     assert_eq!(encoding, expected_encoding);
@@ -15867,7 +15867,7 @@ fn test_containers_single_field_test_struct_max_chaos_1() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x4c00000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -15875,7 +15875,7 @@ fn test_containers_single_field_test_struct_max_chaos_1() {
 
 #[test]
 fn test_containers_single_field_test_struct_max_chaos_2() {
-    let mut value = SingleFieldTestStruct { a: 0 };
+    let value = SingleFieldTestStruct { a: 0 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data("ssz-rs/tests/data/containers/valid/SingleFieldTestStruct_max_chaos_2/serialized.ssz_snappy");
     assert_eq!(encoding, expected_encoding);
@@ -15883,7 +15883,7 @@ fn test_containers_single_field_test_struct_max_chaos_2() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -15891,7 +15891,7 @@ fn test_containers_single_field_test_struct_max_chaos_2() {
 
 #[test]
 fn test_containers_single_field_test_struct_random_0() {
-    let mut value = SingleFieldTestStruct { a: 58 };
+    let value = SingleFieldTestStruct { a: 58 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/containers/valid/SingleFieldTestStruct_random_0/serialized.ssz_snappy",
@@ -15901,7 +15901,7 @@ fn test_containers_single_field_test_struct_random_0() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x3a00000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -15909,7 +15909,7 @@ fn test_containers_single_field_test_struct_random_0() {
 
 #[test]
 fn test_containers_single_field_test_struct_random_1() {
-    let mut value = SingleFieldTestStruct { a: 7 };
+    let value = SingleFieldTestStruct { a: 7 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/containers/valid/SingleFieldTestStruct_random_1/serialized.ssz_snappy",
@@ -15919,7 +15919,7 @@ fn test_containers_single_field_test_struct_random_1() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0700000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -15927,7 +15927,7 @@ fn test_containers_single_field_test_struct_random_1() {
 
 #[test]
 fn test_containers_single_field_test_struct_random_2() {
-    let mut value = SingleFieldTestStruct { a: 249 };
+    let value = SingleFieldTestStruct { a: 249 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/containers/valid/SingleFieldTestStruct_random_2/serialized.ssz_snappy",
@@ -15937,7 +15937,7 @@ fn test_containers_single_field_test_struct_random_2() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf900000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -15945,7 +15945,7 @@ fn test_containers_single_field_test_struct_random_2() {
 
 #[test]
 fn test_containers_single_field_test_struct_random_3() {
-    let mut value = SingleFieldTestStruct { a: 127 };
+    let value = SingleFieldTestStruct { a: 127 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/containers/valid/SingleFieldTestStruct_random_3/serialized.ssz_snappy",
@@ -15955,7 +15955,7 @@ fn test_containers_single_field_test_struct_random_3() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x7f00000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -15963,7 +15963,7 @@ fn test_containers_single_field_test_struct_random_3() {
 
 #[test]
 fn test_containers_single_field_test_struct_random_4() {
-    let mut value = SingleFieldTestStruct { a: 33 };
+    let value = SingleFieldTestStruct { a: 33 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/containers/valid/SingleFieldTestStruct_random_4/serialized.ssz_snappy",
@@ -15973,7 +15973,7 @@ fn test_containers_single_field_test_struct_random_4() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x2100000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -15981,7 +15981,7 @@ fn test_containers_single_field_test_struct_random_4() {
 
 #[test]
 fn test_containers_single_field_test_struct_random_5() {
-    let mut value = SingleFieldTestStruct { a: 238 };
+    let value = SingleFieldTestStruct { a: 238 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/containers/valid/SingleFieldTestStruct_random_5/serialized.ssz_snappy",
@@ -15991,7 +15991,7 @@ fn test_containers_single_field_test_struct_random_5() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xee00000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -15999,7 +15999,7 @@ fn test_containers_single_field_test_struct_random_5() {
 
 #[test]
 fn test_containers_single_field_test_struct_random_6() {
-    let mut value = SingleFieldTestStruct { a: 35 };
+    let value = SingleFieldTestStruct { a: 35 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/containers/valid/SingleFieldTestStruct_random_6/serialized.ssz_snappy",
@@ -16009,7 +16009,7 @@ fn test_containers_single_field_test_struct_random_6() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x2300000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -16017,7 +16017,7 @@ fn test_containers_single_field_test_struct_random_6() {
 
 #[test]
 fn test_containers_single_field_test_struct_random_7() {
-    let mut value = SingleFieldTestStruct { a: 45 };
+    let value = SingleFieldTestStruct { a: 45 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/containers/valid/SingleFieldTestStruct_random_7/serialized.ssz_snappy",
@@ -16027,7 +16027,7 @@ fn test_containers_single_field_test_struct_random_7() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x2d00000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -16035,7 +16035,7 @@ fn test_containers_single_field_test_struct_random_7() {
 
 #[test]
 fn test_containers_single_field_test_struct_random_8() {
-    let mut value = SingleFieldTestStruct { a: 23 };
+    let value = SingleFieldTestStruct { a: 23 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/containers/valid/SingleFieldTestStruct_random_8/serialized.ssz_snappy",
@@ -16045,7 +16045,7 @@ fn test_containers_single_field_test_struct_random_8() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x1700000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -16053,7 +16053,7 @@ fn test_containers_single_field_test_struct_random_8() {
 
 #[test]
 fn test_containers_single_field_test_struct_random_9() {
-    let mut value = SingleFieldTestStruct { a: 138 };
+    let value = SingleFieldTestStruct { a: 138 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/containers/valid/SingleFieldTestStruct_random_9/serialized.ssz_snappy",
@@ -16063,7 +16063,7 @@ fn test_containers_single_field_test_struct_random_9() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x8a00000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -16071,7 +16071,7 @@ fn test_containers_single_field_test_struct_random_9() {
 
 #[test]
 fn test_containers_single_field_test_struct_random_chaos_0() {
-    let mut value = SingleFieldTestStruct { a: 3 };
+    let value = SingleFieldTestStruct { a: 3 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data("ssz-rs/tests/data/containers/valid/SingleFieldTestStruct_random_chaos_0/serialized.ssz_snappy");
     assert_eq!(encoding, expected_encoding);
@@ -16079,7 +16079,7 @@ fn test_containers_single_field_test_struct_random_chaos_0() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0300000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -16087,7 +16087,7 @@ fn test_containers_single_field_test_struct_random_chaos_0() {
 
 #[test]
 fn test_containers_single_field_test_struct_random_chaos_1() {
-    let mut value = SingleFieldTestStruct { a: 17 };
+    let value = SingleFieldTestStruct { a: 17 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data("ssz-rs/tests/data/containers/valid/SingleFieldTestStruct_random_chaos_1/serialized.ssz_snappy");
     assert_eq!(encoding, expected_encoding);
@@ -16095,7 +16095,7 @@ fn test_containers_single_field_test_struct_random_chaos_1() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x1100000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -16103,7 +16103,7 @@ fn test_containers_single_field_test_struct_random_chaos_1() {
 
 #[test]
 fn test_containers_single_field_test_struct_random_chaos_2() {
-    let mut value = SingleFieldTestStruct { a: 42 };
+    let value = SingleFieldTestStruct { a: 42 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data("ssz-rs/tests/data/containers/valid/SingleFieldTestStruct_random_chaos_2/serialized.ssz_snappy");
     assert_eq!(encoding, expected_encoding);
@@ -16111,7 +16111,7 @@ fn test_containers_single_field_test_struct_random_chaos_2() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x2a00000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -16119,7 +16119,7 @@ fn test_containers_single_field_test_struct_random_chaos_2() {
 
 #[test]
 fn test_containers_single_field_test_struct_zero() {
-    let mut value = SingleFieldTestStruct { a: 0 };
+    let value = SingleFieldTestStruct { a: 0 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/containers/valid/SingleFieldTestStruct_zero/serialized.ssz_snappy",
@@ -16129,7 +16129,7 @@ fn test_containers_single_field_test_struct_zero() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -16137,7 +16137,7 @@ fn test_containers_single_field_test_struct_zero() {
 
 #[test]
 fn test_containers_single_field_test_struct_zero_chaos_0() {
-    let mut value = SingleFieldTestStruct { a: 255 };
+    let value = SingleFieldTestStruct { a: 255 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data("ssz-rs/tests/data/containers/valid/SingleFieldTestStruct_zero_chaos_0/serialized.ssz_snappy");
     assert_eq!(encoding, expected_encoding);
@@ -16145,7 +16145,7 @@ fn test_containers_single_field_test_struct_zero_chaos_0() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xff00000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -16153,7 +16153,7 @@ fn test_containers_single_field_test_struct_zero_chaos_0() {
 
 #[test]
 fn test_containers_single_field_test_struct_zero_chaos_1() {
-    let mut value = SingleFieldTestStruct { a: 15 };
+    let value = SingleFieldTestStruct { a: 15 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data("ssz-rs/tests/data/containers/valid/SingleFieldTestStruct_zero_chaos_1/serialized.ssz_snappy");
     assert_eq!(encoding, expected_encoding);
@@ -16161,7 +16161,7 @@ fn test_containers_single_field_test_struct_zero_chaos_1() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0f00000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -16169,7 +16169,7 @@ fn test_containers_single_field_test_struct_zero_chaos_1() {
 
 #[test]
 fn test_containers_single_field_test_struct_zero_chaos_2() {
-    let mut value = SingleFieldTestStruct { a: 255 };
+    let value = SingleFieldTestStruct { a: 255 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data("ssz-rs/tests/data/containers/valid/SingleFieldTestStruct_zero_chaos_2/serialized.ssz_snappy");
     assert_eq!(encoding, expected_encoding);
@@ -16177,7 +16177,7 @@ fn test_containers_single_field_test_struct_zero_chaos_2() {
     let recovered_value: SingleFieldTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xff00000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -16195,7 +16195,7 @@ fn test_containers_small_test_struct_extra_byte() {
 
 #[test]
 fn test_containers_small_test_struct_max() {
-    let mut value = SmallTestStruct { a: 65535, b: 65535 };
+    let value = SmallTestStruct { a: 65535, b: 65535 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/containers/valid/SmallTestStruct_max/serialized.ssz_snappy",
@@ -16205,7 +16205,7 @@ fn test_containers_small_test_struct_max() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x5ee8ff3d8661977c818a2d7f926019872cfef9cf4270b99ff833160f41fc01ec");
     assert_eq!(root, expected_root);
@@ -16213,7 +16213,7 @@ fn test_containers_small_test_struct_max() {
 
 #[test]
 fn test_containers_small_test_struct_max_chaos_0() {
-    let mut value = SmallTestStruct { a: 28192, b: 0 };
+    let value = SmallTestStruct { a: 28192, b: 0 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/containers/valid/SmallTestStruct_max_chaos_0/serialized.ssz_snappy",
@@ -16223,7 +16223,7 @@ fn test_containers_small_test_struct_max_chaos_0() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x006805ecbb4e3f031d5ce707ce5617e4944e1962212f655c71dcfffcb3aae99b");
     assert_eq!(root, expected_root);
@@ -16231,7 +16231,7 @@ fn test_containers_small_test_struct_max_chaos_0() {
 
 #[test]
 fn test_containers_small_test_struct_max_chaos_1() {
-    let mut value = SmallTestStruct { a: 65535, b: 18511 };
+    let value = SmallTestStruct { a: 65535, b: 18511 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/containers/valid/SmallTestStruct_max_chaos_1/serialized.ssz_snappy",
@@ -16241,7 +16241,7 @@ fn test_containers_small_test_struct_max_chaos_1() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x32c367f05a28d3f374ac725e7b9f3ea466012c486d2cb2afc47bbe615e513c4a");
     assert_eq!(root, expected_root);
@@ -16249,7 +16249,7 @@ fn test_containers_small_test_struct_max_chaos_1() {
 
 #[test]
 fn test_containers_small_test_struct_max_chaos_2() {
-    let mut value = SmallTestStruct { a: 65535, b: 5189 };
+    let value = SmallTestStruct { a: 65535, b: 5189 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/containers/valid/SmallTestStruct_max_chaos_2/serialized.ssz_snappy",
@@ -16259,7 +16259,7 @@ fn test_containers_small_test_struct_max_chaos_2() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x8067c7c9cc558dcc9ea3ae383b60db9e1ad5cb1dbff54b0460ca7f942ebfd6a7");
     assert_eq!(root, expected_root);
@@ -16267,7 +16267,7 @@ fn test_containers_small_test_struct_max_chaos_2() {
 
 #[test]
 fn test_containers_small_test_struct_random_0() {
-    let mut value = SmallTestStruct { a: 54558, b: 36278 };
+    let value = SmallTestStruct { a: 54558, b: 36278 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/containers/valid/SmallTestStruct_random_0/serialized.ssz_snappy",
@@ -16277,7 +16277,7 @@ fn test_containers_small_test_struct_random_0() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xab1a70fc42d5926b912ae7f68ec3aba10e8e99415e9863b2e4ca39b4c0c42685");
     assert_eq!(root, expected_root);
@@ -16285,7 +16285,7 @@ fn test_containers_small_test_struct_random_0() {
 
 #[test]
 fn test_containers_small_test_struct_random_1() {
-    let mut value = SmallTestStruct { a: 5269, b: 23244 };
+    let value = SmallTestStruct { a: 5269, b: 23244 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/containers/valid/SmallTestStruct_random_1/serialized.ssz_snappy",
@@ -16295,7 +16295,7 @@ fn test_containers_small_test_struct_random_1() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x78d69e508cfe68f18cf7245e073e0606536efb5e89dee7c2cf9287ca1cc2faf7");
     assert_eq!(root, expected_root);
@@ -16303,7 +16303,7 @@ fn test_containers_small_test_struct_random_1() {
 
 #[test]
 fn test_containers_small_test_struct_random_2() {
-    let mut value = SmallTestStruct { a: 35608, b: 20259 };
+    let value = SmallTestStruct { a: 35608, b: 20259 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/containers/valid/SmallTestStruct_random_2/serialized.ssz_snappy",
@@ -16313,7 +16313,7 @@ fn test_containers_small_test_struct_random_2() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x3f57db803a4eb733537fd43e3c3e05b19011e478879d00efafb82c309efc3884");
     assert_eq!(root, expected_root);
@@ -16321,7 +16321,7 @@ fn test_containers_small_test_struct_random_2() {
 
 #[test]
 fn test_containers_small_test_struct_random_3() {
-    let mut value = SmallTestStruct { a: 39357, b: 20257 };
+    let value = SmallTestStruct { a: 39357, b: 20257 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/containers/valid/SmallTestStruct_random_3/serialized.ssz_snappy",
@@ -16331,7 +16331,7 @@ fn test_containers_small_test_struct_random_3() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xe4e0fd2c3fd96d28c58544b4ed004137777a86ec9c0e66438706b02e5f518f48");
     assert_eq!(root, expected_root);
@@ -16339,7 +16339,7 @@ fn test_containers_small_test_struct_random_3() {
 
 #[test]
 fn test_containers_small_test_struct_random_4() {
-    let mut value = SmallTestStruct { a: 60883, b: 5382 };
+    let value = SmallTestStruct { a: 60883, b: 5382 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/containers/valid/SmallTestStruct_random_4/serialized.ssz_snappy",
@@ -16349,7 +16349,7 @@ fn test_containers_small_test_struct_random_4() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xcb365ed50aa40cb323b64768fc4575b3d07642055a368de7c217f5838e2c7273");
     assert_eq!(root, expected_root);
@@ -16357,7 +16357,7 @@ fn test_containers_small_test_struct_random_4() {
 
 #[test]
 fn test_containers_small_test_struct_random_5() {
-    let mut value = SmallTestStruct { a: 50617, b: 45821 };
+    let value = SmallTestStruct { a: 50617, b: 45821 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/containers/valid/SmallTestStruct_random_5/serialized.ssz_snappy",
@@ -16367,7 +16367,7 @@ fn test_containers_small_test_struct_random_5() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x9ef7194e27a8b01c71347e4ba177ee47417418720d05a6ca67cb875de700a971");
     assert_eq!(root, expected_root);
@@ -16375,7 +16375,7 @@ fn test_containers_small_test_struct_random_5() {
 
 #[test]
 fn test_containers_small_test_struct_random_6() {
-    let mut value = SmallTestStruct { a: 64992, b: 44788 };
+    let value = SmallTestStruct { a: 64992, b: 44788 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/containers/valid/SmallTestStruct_random_6/serialized.ssz_snappy",
@@ -16385,7 +16385,7 @@ fn test_containers_small_test_struct_random_6() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xef90a603c65f807f800fa6c96e6f2e00f5445e057b239ce5be1f8c239387f2cd");
     assert_eq!(root, expected_root);
@@ -16393,7 +16393,7 @@ fn test_containers_small_test_struct_random_6() {
 
 #[test]
 fn test_containers_small_test_struct_random_7() {
-    let mut value = SmallTestStruct { a: 61357, b: 62381 };
+    let value = SmallTestStruct { a: 61357, b: 62381 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/containers/valid/SmallTestStruct_random_7/serialized.ssz_snappy",
@@ -16403,7 +16403,7 @@ fn test_containers_small_test_struct_random_7() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x7863111a4784d0e710f7933c38fb6c21764654482360cb43c65c5730aa3e420d");
     assert_eq!(root, expected_root);
@@ -16411,7 +16411,7 @@ fn test_containers_small_test_struct_random_7() {
 
 #[test]
 fn test_containers_small_test_struct_random_8() {
-    let mut value = SmallTestStruct { a: 5941, b: 61713 };
+    let value = SmallTestStruct { a: 5941, b: 61713 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/containers/valid/SmallTestStruct_random_8/serialized.ssz_snappy",
@@ -16421,7 +16421,7 @@ fn test_containers_small_test_struct_random_8() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x415461b066dcc4b21f7fb2b51f24f6ae8bf360b0de9ffb72f2d6e798da9ad400");
     assert_eq!(root, expected_root);
@@ -16429,7 +16429,7 @@ fn test_containers_small_test_struct_random_8() {
 
 #[test]
 fn test_containers_small_test_struct_random_9() {
-    let mut value = SmallTestStruct { a: 22278, b: 57618 };
+    let value = SmallTestStruct { a: 22278, b: 57618 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/containers/valid/SmallTestStruct_random_9/serialized.ssz_snappy",
@@ -16439,7 +16439,7 @@ fn test_containers_small_test_struct_random_9() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x859b42be5e5c733e8ab234c5f09a5e91b87c070d72740d6a8890995690a9acc5");
     assert_eq!(root, expected_root);
@@ -16447,7 +16447,7 @@ fn test_containers_small_test_struct_random_9() {
 
 #[test]
 fn test_containers_small_test_struct_random_chaos_0() {
-    let mut value = SmallTestStruct { a: 39639, b: 46561 };
+    let value = SmallTestStruct { a: 39639, b: 46561 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/containers/valid/SmallTestStruct_random_chaos_0/serialized.ssz_snappy",
@@ -16457,7 +16457,7 @@ fn test_containers_small_test_struct_random_chaos_0() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x37a05524f5a46555c6f1924c6c1b67218e760596b42f53dadd6db5ff876cd660");
     assert_eq!(root, expected_root);
@@ -16465,7 +16465,7 @@ fn test_containers_small_test_struct_random_chaos_0() {
 
 #[test]
 fn test_containers_small_test_struct_random_chaos_1() {
-    let mut value = SmallTestStruct { a: 0, b: 26218 };
+    let value = SmallTestStruct { a: 0, b: 26218 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/containers/valid/SmallTestStruct_random_chaos_1/serialized.ssz_snappy",
@@ -16475,7 +16475,7 @@ fn test_containers_small_test_struct_random_chaos_1() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xa278a189a4d8b4909ad5bbfbb4bacc31005e1e4fcbcbb0bf7caa604cf92ab166");
     assert_eq!(root, expected_root);
@@ -16483,7 +16483,7 @@ fn test_containers_small_test_struct_random_chaos_1() {
 
 #[test]
 fn test_containers_small_test_struct_random_chaos_2() {
-    let mut value = SmallTestStruct { a: 2529, b: 9252 };
+    let value = SmallTestStruct { a: 2529, b: 9252 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/containers/valid/SmallTestStruct_random_chaos_2/serialized.ssz_snappy",
@@ -16493,7 +16493,7 @@ fn test_containers_small_test_struct_random_chaos_2() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xc0bb95db0a18e3538a7d1bc39ce8227bb028c8f68bc74bee7150560a4f1b0887");
     assert_eq!(root, expected_root);
@@ -16501,7 +16501,7 @@ fn test_containers_small_test_struct_random_chaos_2() {
 
 #[test]
 fn test_containers_small_test_struct_zero() {
-    let mut value = SmallTestStruct { a: 0, b: 0 };
+    let value = SmallTestStruct { a: 0, b: 0 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/containers/valid/SmallTestStruct_zero/serialized.ssz_snappy",
@@ -16511,7 +16511,7 @@ fn test_containers_small_test_struct_zero() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b");
     assert_eq!(root, expected_root);
@@ -16519,7 +16519,7 @@ fn test_containers_small_test_struct_zero() {
 
 #[test]
 fn test_containers_small_test_struct_zero_chaos_0() {
-    let mut value = SmallTestStruct { a: 65535, b: 0 };
+    let value = SmallTestStruct { a: 65535, b: 0 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/containers/valid/SmallTestStruct_zero_chaos_0/serialized.ssz_snappy",
@@ -16529,7 +16529,7 @@ fn test_containers_small_test_struct_zero_chaos_0() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x9f0a4f1b805c05c92e76c5d1479d46d0515834106f56fa521febbbaef26902be");
     assert_eq!(root, expected_root);
@@ -16537,7 +16537,7 @@ fn test_containers_small_test_struct_zero_chaos_0() {
 
 #[test]
 fn test_containers_small_test_struct_zero_chaos_1() {
-    let mut value = SmallTestStruct { a: 49459, b: 0 };
+    let value = SmallTestStruct { a: 49459, b: 0 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/containers/valid/SmallTestStruct_zero_chaos_1/serialized.ssz_snappy",
@@ -16547,7 +16547,7 @@ fn test_containers_small_test_struct_zero_chaos_1() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x8aa53bd0929b0cefb8834c52af0ef93b01141666adc535a1e4181e3061bb77b7");
     assert_eq!(root, expected_root);
@@ -16555,7 +16555,7 @@ fn test_containers_small_test_struct_zero_chaos_1() {
 
 #[test]
 fn test_containers_small_test_struct_zero_chaos_2() {
-    let mut value = SmallTestStruct { a: 65087, b: 0 };
+    let value = SmallTestStruct { a: 65087, b: 0 };
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/containers/valid/SmallTestStruct_zero_chaos_2/serialized.ssz_snappy",
@@ -16565,7 +16565,7 @@ fn test_containers_small_test_struct_zero_chaos_2() {
     let recovered_value: SmallTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x9efcc36dc09f38bf60ee694007c1e5ee80d7dc10c6db68c17e5fb33dbd25bb5a");
     assert_eq!(root, expected_root);
@@ -16583,7 +16583,7 @@ fn test_containers_var_test_struct_extra_byte() {
 
 #[test]
 fn test_containers_var_test_struct_lengthy_0() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 17006,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([
             22717, 10092, 23181, 44132, 56083, 9786, 18029, 6053, 14557, 30014, 52849, 53581, 1706,
@@ -16682,7 +16682,7 @@ fn test_containers_var_test_struct_lengthy_0() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x91c099892139bf956ca5617b630e4c2e5375af8ffabc70d23112f44606845f78");
     assert_eq!(root, expected_root);
@@ -16690,7 +16690,7 @@ fn test_containers_var_test_struct_lengthy_0() {
 
 #[test]
 fn test_containers_var_test_struct_lengthy_1() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 51340,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([
             47589, 20821, 19661, 27886, 43003, 60221, 64176, 49983, 28476, 34857, 4565, 56689,
@@ -16789,7 +16789,7 @@ fn test_containers_var_test_struct_lengthy_1() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xdb86f83887def79e8136565c15109754858ad4020a5ca615b213f657bbc47a6e");
     assert_eq!(root, expected_root);
@@ -16797,7 +16797,7 @@ fn test_containers_var_test_struct_lengthy_1() {
 
 #[test]
 fn test_containers_var_test_struct_lengthy_2() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 62388,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([
             15173, 48097, 34784, 17125, 53078, 63472, 59950, 51563, 46205, 28969, 11302, 34038,
@@ -16896,7 +16896,7 @@ fn test_containers_var_test_struct_lengthy_2() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xd9e504e079375d102319315806576a257499618495abd7374383895c6e6c9c86");
     assert_eq!(root, expected_root);
@@ -16904,7 +16904,7 @@ fn test_containers_var_test_struct_lengthy_2() {
 
 #[test]
 fn test_containers_var_test_struct_lengthy_3() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 20604,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([
             34957, 22356, 49238, 15530, 12659, 22637, 4844, 40024, 12527, 63141, 52298, 1765,
@@ -17003,7 +17003,7 @@ fn test_containers_var_test_struct_lengthy_3() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x403fec5d885fc3b79002c68502f5884a13139045f7d584299d4aa6440c621a08");
     assert_eq!(root, expected_root);
@@ -17011,7 +17011,7 @@ fn test_containers_var_test_struct_lengthy_3() {
 
 #[test]
 fn test_containers_var_test_struct_lengthy_4() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 31723,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([
             54898, 17572, 14430, 62910, 3421, 12689, 12978, 26233, 431, 28622, 46748, 44543, 51497,
@@ -17111,7 +17111,7 @@ fn test_containers_var_test_struct_lengthy_4() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xc52442fb8e6d1d382578c0506a26d9f7a88ca1f40913e825f93a2ce12d8ccb9f");
     assert_eq!(root, expected_root);
@@ -17119,7 +17119,7 @@ fn test_containers_var_test_struct_lengthy_4() {
 
 #[test]
 fn test_containers_var_test_struct_lengthy_5() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 62701,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([
             13450, 24351, 51399, 56826, 60224, 65266, 53856, 23188, 34504, 34114, 15786, 19629,
@@ -17218,7 +17218,7 @@ fn test_containers_var_test_struct_lengthy_5() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x3d9572d393c997f81bbf98bf9bbc40ee291d5f798c8fc8fbe0ff668db6432b8c");
     assert_eq!(root, expected_root);
@@ -17226,7 +17226,7 @@ fn test_containers_var_test_struct_lengthy_5() {
 
 #[test]
 fn test_containers_var_test_struct_lengthy_6() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 55972,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([
             11399, 15291, 30938, 30612, 5398, 6772, 58525, 31460, 46486, 44751, 50458, 7858, 43542,
@@ -17325,7 +17325,7 @@ fn test_containers_var_test_struct_lengthy_6() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xe408e32f2280694b2fe31693dd5ac1bfada7abeff3d7de21539eb51a87beb1cd");
     assert_eq!(root, expected_root);
@@ -17333,7 +17333,7 @@ fn test_containers_var_test_struct_lengthy_6() {
 
 #[test]
 fn test_containers_var_test_struct_lengthy_7() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 44853,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([
             62481, 28416, 26298, 58537, 60679, 56277, 19174, 41894, 17873, 64750, 9105, 19665,
@@ -17432,7 +17432,7 @@ fn test_containers_var_test_struct_lengthy_7() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x47415855521dd2b3c7928c4fa89f4e8fd64308b8a8f310c35319976154e8df3b");
     assert_eq!(root, expected_root);
@@ -17440,7 +17440,7 @@ fn test_containers_var_test_struct_lengthy_7() {
 
 #[test]
 fn test_containers_var_test_struct_lengthy_8() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 20549,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([
             3953, 42181, 26705, 51056, 39573, 25650, 49315, 48964, 13112, 56492, 18886, 45518, 130,
@@ -17539,7 +17539,7 @@ fn test_containers_var_test_struct_lengthy_8() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xde9f1e6dbba6727cd87bea1d93ac0f92ac4b889c5d3a483650af23e10712621d");
     assert_eq!(root, expected_root);
@@ -17547,7 +17547,7 @@ fn test_containers_var_test_struct_lengthy_8() {
 
 #[test]
 fn test_containers_var_test_struct_lengthy_9() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 36734,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([
             19081, 32810, 33919, 8568, 20609, 44802, 35110, 36218, 59983, 22518, 1472, 41772,
@@ -17647,7 +17647,7 @@ fn test_containers_var_test_struct_lengthy_9() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xcd9fe8ea8862ba4f70244b0649956fb3584ac19580eeb413d3c8d6754e0eb21e");
     assert_eq!(root, expected_root);
@@ -17655,7 +17655,7 @@ fn test_containers_var_test_struct_lengthy_9() {
 
 #[test]
 fn test_containers_var_test_struct_lengthy_chaos_0() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 60445,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([
             41248, 0, 65535, 65535, 60137, 57750, 11223, 65535, 65535, 11355, 16613, 3189, 24359,
@@ -17681,7 +17681,7 @@ fn test_containers_var_test_struct_lengthy_chaos_0() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x6f6184da799c0ebf0154aa56847a4d491a8f62f317d018334bf7367fee6f31a4");
     assert_eq!(root, expected_root);
@@ -17689,7 +17689,7 @@ fn test_containers_var_test_struct_lengthy_chaos_0() {
 
 #[test]
 fn test_containers_var_test_struct_lengthy_chaos_1() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 1543,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([51731])).unwrap(),
         c: 220,
@@ -17703,7 +17703,7 @@ fn test_containers_var_test_struct_lengthy_chaos_1() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xee381964ccbada8328e12c5b1f25b3c47ad1930cb99d9d4e1be20bc0a7e3e143");
     assert_eq!(root, expected_root);
@@ -17711,7 +17711,7 @@ fn test_containers_var_test_struct_lengthy_chaos_1() {
 
 #[test]
 fn test_containers_var_test_struct_lengthy_chaos_2() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 30938,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([])).unwrap(),
         c: 0,
@@ -17725,7 +17725,7 @@ fn test_containers_var_test_struct_lengthy_chaos_2() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xc2ab319d105839cf5f2740dca530f09f84f06feef99e5c8672811cc0a554fd54");
     assert_eq!(root, expected_root);
@@ -17765,7 +17765,7 @@ fn test_containers_var_test_struct_lengthy_offset_2_zeroed() {
 
 #[test]
 fn test_containers_var_test_struct_max() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 65535,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([
             65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
@@ -17862,7 +17862,7 @@ fn test_containers_var_test_struct_max() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x15e9ad3c97423dc2d351f940bfbff9a4dec9770850ddd9225b34237e118adc7c");
     assert_eq!(root, expected_root);
@@ -17870,7 +17870,7 @@ fn test_containers_var_test_struct_max() {
 
 #[test]
 fn test_containers_var_test_struct_max_0() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 65535,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([
             65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
@@ -17963,7 +17963,7 @@ fn test_containers_var_test_struct_max_0() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x56580a519ee0bb5185653c7acb73abe3db0d43a0075aa93d10eab9fa37a68ac6");
     assert_eq!(root, expected_root);
@@ -17971,7 +17971,7 @@ fn test_containers_var_test_struct_max_0() {
 
 #[test]
 fn test_containers_var_test_struct_max_1() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 65535,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([
             65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
@@ -18063,7 +18063,7 @@ fn test_containers_var_test_struct_max_1() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x325f49ca48bb009071c1af915c2affdf0115a990516ec4f8519c1160dd9f64d7");
     assert_eq!(root, expected_root);
@@ -18071,7 +18071,7 @@ fn test_containers_var_test_struct_max_1() {
 
 #[test]
 fn test_containers_var_test_struct_max_2() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 65535,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([
             65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
@@ -18121,7 +18121,7 @@ fn test_containers_var_test_struct_max_2() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xcab1dfb713ab90635b4c202630a0a178fb5b1b4cbc72695faf5ecb81a94cff8c");
     assert_eq!(root, expected_root);
@@ -18129,7 +18129,7 @@ fn test_containers_var_test_struct_max_2() {
 
 #[test]
 fn test_containers_var_test_struct_max_3() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 65535,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([
             65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
@@ -18150,7 +18150,7 @@ fn test_containers_var_test_struct_max_3() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xb49546827cdbce75f2facc47daab8ec3886f914e1f7f1756ebc7d17bfeccc617");
     assert_eq!(root, expected_root);
@@ -18158,7 +18158,7 @@ fn test_containers_var_test_struct_max_3() {
 
 #[test]
 fn test_containers_var_test_struct_max_4() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 65535,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([
             65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
@@ -18178,7 +18178,7 @@ fn test_containers_var_test_struct_max_4() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xfa233782570411ce535e4d9fdb537990d5f40437d2d85d463ca3e7dad4a74d9f");
     assert_eq!(root, expected_root);
@@ -18186,7 +18186,7 @@ fn test_containers_var_test_struct_max_4() {
 
 #[test]
 fn test_containers_var_test_struct_max_5() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 65535,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([
             65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
@@ -18217,7 +18217,7 @@ fn test_containers_var_test_struct_max_5() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x566b5e483ba5cb5ef93506a1b711df754e93308b118b13e046d6e9ad74418273");
     assert_eq!(root, expected_root);
@@ -18225,7 +18225,7 @@ fn test_containers_var_test_struct_max_5() {
 
 #[test]
 fn test_containers_var_test_struct_max_6() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 65535,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([
             65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
@@ -18282,7 +18282,7 @@ fn test_containers_var_test_struct_max_6() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x714e5d28c6cadb4c41c52ff0873f5eedefcc3a29e79d4c50310cda970687abb8");
     assert_eq!(root, expected_root);
@@ -18290,7 +18290,7 @@ fn test_containers_var_test_struct_max_6() {
 
 #[test]
 fn test_containers_var_test_struct_max_7() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 65535,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([
             65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
@@ -18353,7 +18353,7 @@ fn test_containers_var_test_struct_max_7() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x8bb40c9d2ea53fd72efb9b07c1f91f35fa9c884869734074a50011e9b4571882");
     assert_eq!(root, expected_root);
@@ -18361,7 +18361,7 @@ fn test_containers_var_test_struct_max_7() {
 
 #[test]
 fn test_containers_var_test_struct_max_8() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 65535,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([
             65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
@@ -18403,7 +18403,7 @@ fn test_containers_var_test_struct_max_8() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x234d219bcd661de659d3675a667e74c56720d96fbe1c3c1f866a4579e84e9b7f");
     assert_eq!(root, expected_root);
@@ -18411,7 +18411,7 @@ fn test_containers_var_test_struct_max_8() {
 
 #[test]
 fn test_containers_var_test_struct_max_9() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 65535,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([
             65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
@@ -18487,7 +18487,7 @@ fn test_containers_var_test_struct_max_9() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xc0797bf78883955d067a148d7b37737debccf2e7b16107e3480156744565b8b8");
     assert_eq!(root, expected_root);
@@ -18495,7 +18495,7 @@ fn test_containers_var_test_struct_max_9() {
 
 #[test]
 fn test_containers_var_test_struct_max_chaos_0() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 65535,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([])).unwrap(),
         c: 255,
@@ -18509,7 +18509,7 @@ fn test_containers_var_test_struct_max_chaos_0() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xdcbe7541bc36b70f18046e6312563a5315d439a69a088931ee0daca2fdd2440b");
     assert_eq!(root, expected_root);
@@ -18517,7 +18517,7 @@ fn test_containers_var_test_struct_max_chaos_0() {
 
 #[test]
 fn test_containers_var_test_struct_max_chaos_1() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 23436,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([])).unwrap(),
         c: 255,
@@ -18531,7 +18531,7 @@ fn test_containers_var_test_struct_max_chaos_1() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x16a0be99b3ef5107a5959bb009cf98c8a5a37aeeafd1b966c84b3c630186cfc3");
     assert_eq!(root, expected_root);
@@ -18539,7 +18539,7 @@ fn test_containers_var_test_struct_max_chaos_1() {
 
 #[test]
 fn test_containers_var_test_struct_max_chaos_2() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 1123,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([
             7029, 0, 1713, 15092, 0, 28021, 22657, 65535, 0, 45891, 52860, 22869, 26735, 727,
@@ -18631,7 +18631,7 @@ fn test_containers_var_test_struct_max_chaos_2() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xe0364b8fc432a7b5849ca9453cfdade41ede56abc18f93b71433f11eff8755a6");
     assert_eq!(root, expected_root);
@@ -18639,7 +18639,7 @@ fn test_containers_var_test_struct_max_chaos_2() {
 
 #[test]
 fn test_containers_var_test_struct_nil_0() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 46959,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([])).unwrap(),
         c: 40,
@@ -18653,7 +18653,7 @@ fn test_containers_var_test_struct_nil_0() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x50683dbb595c06624e23b54b9a9aab8245af7b19e0c23e3cd35c5ccaa0beed8e");
     assert_eq!(root, expected_root);
@@ -18661,7 +18661,7 @@ fn test_containers_var_test_struct_nil_0() {
 
 #[test]
 fn test_containers_var_test_struct_nil_1() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 55458,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([])).unwrap(),
         c: 194,
@@ -18675,7 +18675,7 @@ fn test_containers_var_test_struct_nil_1() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x67d4e19ce21a6f72866a977768ebf9ee04cbe3b6769f44c58b3f6e53c0fa6a35");
     assert_eq!(root, expected_root);
@@ -18683,7 +18683,7 @@ fn test_containers_var_test_struct_nil_1() {
 
 #[test]
 fn test_containers_var_test_struct_nil_2() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 56441,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([])).unwrap(),
         c: 118,
@@ -18697,7 +18697,7 @@ fn test_containers_var_test_struct_nil_2() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x695bc170943f72a828f0a0b1cb861ca3df701de71b08b87831e69bf61f0e0e3e");
     assert_eq!(root, expected_root);
@@ -18705,7 +18705,7 @@ fn test_containers_var_test_struct_nil_2() {
 
 #[test]
 fn test_containers_var_test_struct_nil_3() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 51959,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([])).unwrap(),
         c: 229,
@@ -18719,7 +18719,7 @@ fn test_containers_var_test_struct_nil_3() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x5f6b6e1b555aab6e53e8d53c23e768616ff751c9da3d0573c0c2fd6b1b0f1b45");
     assert_eq!(root, expected_root);
@@ -18727,7 +18727,7 @@ fn test_containers_var_test_struct_nil_3() {
 
 #[test]
 fn test_containers_var_test_struct_nil_4() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 55400,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([])).unwrap(),
         c: 204,
@@ -18741,7 +18741,7 @@ fn test_containers_var_test_struct_nil_4() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xbbf774ab4d952407bddbcc33e3f28482ab974102d9666fa00b5d927e1cb05082");
     assert_eq!(root, expected_root);
@@ -18749,7 +18749,7 @@ fn test_containers_var_test_struct_nil_4() {
 
 #[test]
 fn test_containers_var_test_struct_nil_5() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 60183,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([])).unwrap(),
         c: 81,
@@ -18763,7 +18763,7 @@ fn test_containers_var_test_struct_nil_5() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x13937b49bed01535ecf11e8afb110d8ceae82a481be8e77157e62f031b91d25c");
     assert_eq!(root, expected_root);
@@ -18771,7 +18771,7 @@ fn test_containers_var_test_struct_nil_5() {
 
 #[test]
 fn test_containers_var_test_struct_nil_6() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 44944,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([])).unwrap(),
         c: 138,
@@ -18785,7 +18785,7 @@ fn test_containers_var_test_struct_nil_6() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x9c0ac1fd37b09b9259a7d26c70e9bcb122af290f3c51dff941d7178f649807f1");
     assert_eq!(root, expected_root);
@@ -18793,7 +18793,7 @@ fn test_containers_var_test_struct_nil_6() {
 
 #[test]
 fn test_containers_var_test_struct_nil_7() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 28606,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([])).unwrap(),
         c: 108,
@@ -18807,7 +18807,7 @@ fn test_containers_var_test_struct_nil_7() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x2c193129d8189cced897c240632e249e85ded4ee7a5af48ba4222254194afbf9");
     assert_eq!(root, expected_root);
@@ -18815,7 +18815,7 @@ fn test_containers_var_test_struct_nil_7() {
 
 #[test]
 fn test_containers_var_test_struct_nil_8() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 20040,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([])).unwrap(),
         c: 226,
@@ -18829,7 +18829,7 @@ fn test_containers_var_test_struct_nil_8() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x4feef9858a3460aac32922ce090914cb1a66c9232f92e6ddcb2672ba34e85f12");
     assert_eq!(root, expected_root);
@@ -18837,7 +18837,7 @@ fn test_containers_var_test_struct_nil_8() {
 
 #[test]
 fn test_containers_var_test_struct_nil_9() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 16949,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([])).unwrap(),
         c: 54,
@@ -18851,7 +18851,7 @@ fn test_containers_var_test_struct_nil_9() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xdc7656b3be9495ff7f31a568ac0cbfd73abf7081726578d5c42401fad0168ae9");
     assert_eq!(root, expected_root);
@@ -18859,7 +18859,7 @@ fn test_containers_var_test_struct_nil_9() {
 
 #[test]
 fn test_containers_var_test_struct_nil_chaos_0() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 5285,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([
             0, 25201, 0, 16037, 31280, 65535, 33272, 11848, 3343, 65535, 60290, 46167, 18257,
@@ -18949,7 +18949,7 @@ fn test_containers_var_test_struct_nil_chaos_0() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xbff50cbed553df006a7ad81b7dc89c1a9a5fd7c8d5e9e3e55a6bc4112cf6a0b1");
     assert_eq!(root, expected_root);
@@ -18957,7 +18957,7 @@ fn test_containers_var_test_struct_nil_chaos_0() {
 
 #[test]
 fn test_containers_var_test_struct_nil_chaos_1() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 19203,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([])).unwrap(),
         c: 143,
@@ -18971,7 +18971,7 @@ fn test_containers_var_test_struct_nil_chaos_1() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x63652fbaf8d9d6069f52ef3d06f6e61915b8033746fc69bcaabdef6daf69cf1f");
     assert_eq!(root, expected_root);
@@ -18979,7 +18979,7 @@ fn test_containers_var_test_struct_nil_chaos_1() {
 
 #[test]
 fn test_containers_var_test_struct_nil_chaos_2() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 19771,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([41167])).unwrap(),
         c: 94,
@@ -18993,7 +18993,7 @@ fn test_containers_var_test_struct_nil_chaos_2() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xbe0f5ed20e35ba55f1d00c027a5f9a44b269eefa31d7de8647abb984a5874981");
     assert_eq!(root, expected_root);
@@ -19025,7 +19025,7 @@ fn test_containers_var_test_struct_nil_offset_2_zeroed() {
 
 #[test]
 fn test_containers_var_test_struct_one_0() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 13373,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([31906])).unwrap(),
         c: 63,
@@ -19039,7 +19039,7 @@ fn test_containers_var_test_struct_one_0() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x15d8fbc422bd7e8dcd7d6dd01b0c520953301abe056d134e1b5f06ed6a34a7f2");
     assert_eq!(root, expected_root);
@@ -19047,7 +19047,7 @@ fn test_containers_var_test_struct_one_0() {
 
 #[test]
 fn test_containers_var_test_struct_one_1() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 5133,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([18771])).unwrap(),
         c: 183,
@@ -19061,7 +19061,7 @@ fn test_containers_var_test_struct_one_1() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x4899c18db80f87208bbc34681b3c19e8fed493b3aa7b1f33e792d192f9c988a5");
     assert_eq!(root, expected_root);
@@ -19069,7 +19069,7 @@ fn test_containers_var_test_struct_one_1() {
 
 #[test]
 fn test_containers_var_test_struct_one_2() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 6105,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([26812])).unwrap(),
         c: 6,
@@ -19083,7 +19083,7 @@ fn test_containers_var_test_struct_one_2() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x041dd05e1f7b1a9a1074ba2fee348b8ebd72db7fc8009c2659a03a968dfddc57");
     assert_eq!(root, expected_root);
@@ -19091,7 +19091,7 @@ fn test_containers_var_test_struct_one_2() {
 
 #[test]
 fn test_containers_var_test_struct_one_3() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 3451,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([45630])).unwrap(),
         c: 227,
@@ -19105,7 +19105,7 @@ fn test_containers_var_test_struct_one_3() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xeaac8045bfb7091e56c92d4d1cec95a3df282ffeecee43ec96c3433930806cc2");
     assert_eq!(root, expected_root);
@@ -19113,7 +19113,7 @@ fn test_containers_var_test_struct_one_3() {
 
 #[test]
 fn test_containers_var_test_struct_one_4() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 32090,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([18295])).unwrap(),
         c: 17,
@@ -19127,7 +19127,7 @@ fn test_containers_var_test_struct_one_4() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x4e4d3794a045d1c25d43fdb283932f7c830f9e93ed0716bdda8c4e8b19000933");
     assert_eq!(root, expected_root);
@@ -19135,7 +19135,7 @@ fn test_containers_var_test_struct_one_4() {
 
 #[test]
 fn test_containers_var_test_struct_one_5() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 30693,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([24817])).unwrap(),
         c: 213,
@@ -19149,7 +19149,7 @@ fn test_containers_var_test_struct_one_5() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xa0b55c31403744e66948427e585a2fe66b8f0b26454e52d11e15d9ea43ebae17");
     assert_eq!(root, expected_root);
@@ -19157,7 +19157,7 @@ fn test_containers_var_test_struct_one_5() {
 
 #[test]
 fn test_containers_var_test_struct_one_6() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 39023,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([18503])).unwrap(),
         c: 120,
@@ -19171,7 +19171,7 @@ fn test_containers_var_test_struct_one_6() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x9735380cbd6f8519644148d132f911a786c0eb47e1f04e65e57ebad8fe56b8ff");
     assert_eq!(root, expected_root);
@@ -19179,7 +19179,7 @@ fn test_containers_var_test_struct_one_6() {
 
 #[test]
 fn test_containers_var_test_struct_one_7() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 51727,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([63012])).unwrap(),
         c: 142,
@@ -19193,7 +19193,7 @@ fn test_containers_var_test_struct_one_7() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xad8a125fdaa8db83b1fc9d7423a811170584e2e2be39f8644d3e4f01505a7acf");
     assert_eq!(root, expected_root);
@@ -19201,7 +19201,7 @@ fn test_containers_var_test_struct_one_7() {
 
 #[test]
 fn test_containers_var_test_struct_one_8() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 14916,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([39519])).unwrap(),
         c: 4,
@@ -19215,7 +19215,7 @@ fn test_containers_var_test_struct_one_8() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xa5b1584410838d0961fbb3933d3acf55b4bb50bae0fd55acd95077a0079d29a7");
     assert_eq!(root, expected_root);
@@ -19223,7 +19223,7 @@ fn test_containers_var_test_struct_one_8() {
 
 #[test]
 fn test_containers_var_test_struct_one_9() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 18626,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([52279])).unwrap(),
         c: 157,
@@ -19237,7 +19237,7 @@ fn test_containers_var_test_struct_one_9() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xc457b698aee081685c2ff7536da84413b7c27a9ccd7f0c0f1c5b4d41dcf7b4d9");
     assert_eq!(root, expected_root);
@@ -19245,7 +19245,7 @@ fn test_containers_var_test_struct_one_9() {
 
 #[test]
 fn test_containers_var_test_struct_one_chaos_0() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 40138,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([
             65535, 0, 31331, 0, 34012, 65535, 51817, 65535, 53427, 0, 28979, 15627, 65535, 0, 0,
@@ -19327,7 +19327,7 @@ fn test_containers_var_test_struct_one_chaos_0() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x75a21e43d653f955dcaa219e22bd3c802e6ee0787005f203fd24b94c0cc26918");
     assert_eq!(root, expected_root);
@@ -19335,7 +19335,7 @@ fn test_containers_var_test_struct_one_chaos_0() {
 
 #[test]
 fn test_containers_var_test_struct_one_chaos_1() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 30440,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([])).unwrap(),
         c: 0,
@@ -19349,7 +19349,7 @@ fn test_containers_var_test_struct_one_chaos_1() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x6b8e9bdd7303c481cd6f00e9051e8eb081b07699e806f5ed750d8405f92e52f1");
     assert_eq!(root, expected_root);
@@ -19357,7 +19357,7 @@ fn test_containers_var_test_struct_one_chaos_1() {
 
 #[test]
 fn test_containers_var_test_struct_one_chaos_2() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 0,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([
             41095, 65535, 28658, 44280, 65535, 65535, 19737, 61292, 19192, 0, 12891, 65535, 0,
@@ -19422,7 +19422,7 @@ fn test_containers_var_test_struct_one_chaos_2() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x70cc1bfa7fb688bab448160b81321a6a245a8847e671257b95e9ddc6043efc1d");
     assert_eq!(root, expected_root);
@@ -19462,7 +19462,7 @@ fn test_containers_var_test_struct_one_offset_2_zeroed() {
 
 #[test]
 fn test_containers_var_test_struct_random_0() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 13603,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([
             36974, 14793, 41047, 42644, 47525, 8585, 41126, 3068, 61868, 32452, 52070, 33625,
@@ -19529,7 +19529,7 @@ fn test_containers_var_test_struct_random_0() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf7c368f32d7a4842614e5b13e4d4df0423427c72aa564c7743265ef21217f744");
     assert_eq!(root, expected_root);
@@ -19537,7 +19537,7 @@ fn test_containers_var_test_struct_random_0() {
 
 #[test]
 fn test_containers_var_test_struct_random_1() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 12339,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([
             6435, 5027, 12935, 58835, 25601, 42816, 55130, 46980, 33955, 2700, 62344, 26772, 49951,
@@ -19580,7 +19580,7 @@ fn test_containers_var_test_struct_random_1() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xe1b98199d4cb498e33bf2efdbaa2fdde0efa008171804b1ec780bfc2f20fa12d");
     assert_eq!(root, expected_root);
@@ -19588,7 +19588,7 @@ fn test_containers_var_test_struct_random_1() {
 
 #[test]
 fn test_containers_var_test_struct_random_2() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 205,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([
             50820, 37658, 24377, 10169, 41075, 53746, 8356, 25932, 45622, 27068, 52763, 3905,
@@ -19626,7 +19626,7 @@ fn test_containers_var_test_struct_random_2() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x990f1a2c4c2362a7c59bbf94a93ac6898f23516b4e8144c23bf68d6c152df640");
     assert_eq!(root, expected_root);
@@ -19634,7 +19634,7 @@ fn test_containers_var_test_struct_random_2() {
 
 #[test]
 fn test_containers_var_test_struct_random_3() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 59954,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([
             47544, 35901, 35508, 52836, 1719, 31754, 34244, 52550, 16561, 58801, 25853, 43681,
@@ -19728,7 +19728,7 @@ fn test_containers_var_test_struct_random_3() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x41d081029855c4979db545ce107d84ef51497ce93419d43d2ed3ee7d85660b6a");
     assert_eq!(root, expected_root);
@@ -19736,7 +19736,7 @@ fn test_containers_var_test_struct_random_3() {
 
 #[test]
 fn test_containers_var_test_struct_random_4() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 64822,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([
             16734, 9497, 13409, 58763, 25059, 15369, 39800, 59064, 57777, 39067, 51491, 16990,
@@ -19813,7 +19813,7 @@ fn test_containers_var_test_struct_random_4() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xd6139a50ec151d61a71e52f8bd45e3b30bed9b3aaa69c833c3da30bd36d243e4");
     assert_eq!(root, expected_root);
@@ -19821,7 +19821,7 @@ fn test_containers_var_test_struct_random_4() {
 
 #[test]
 fn test_containers_var_test_struct_random_5() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 27545,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([
             21413, 8654, 13117, 51057, 44329, 9178, 12592, 57532, 49952, 31, 62331, 54527, 20925,
@@ -19892,7 +19892,7 @@ fn test_containers_var_test_struct_random_5() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xe72553d4b1b08c4c64c3b7781bba9d4c6eb20c6cb6c2cb91fd10b3004d9cbf6b");
     assert_eq!(root, expected_root);
@@ -19900,7 +19900,7 @@ fn test_containers_var_test_struct_random_5() {
 
 #[test]
 fn test_containers_var_test_struct_random_6() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 2546,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([
             34018, 8390, 30159, 22918, 60518, 657, 6213, 58030, 24457, 42466, 40615, 18842, 17930,
@@ -19940,7 +19940,7 @@ fn test_containers_var_test_struct_random_6() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf7d6dd5cae0fef7e20398d9b7032e2432627bac1bd36af4ae0282af071a2d9f3");
     assert_eq!(root, expected_root);
@@ -19948,7 +19948,7 @@ fn test_containers_var_test_struct_random_6() {
 
 #[test]
 fn test_containers_var_test_struct_random_7() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 32956,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([
             27138, 27095, 53009, 54159, 8538, 53786, 56204, 29089, 35375, 14190, 46500, 3428,
@@ -20023,7 +20023,7 @@ fn test_containers_var_test_struct_random_7() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x4b6da8debc43236f10ae7a472cbae050e165235867af5cea48d89e370815e23c");
     assert_eq!(root, expected_root);
@@ -20031,7 +20031,7 @@ fn test_containers_var_test_struct_random_7() {
 
 #[test]
 fn test_containers_var_test_struct_random_8() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 2060,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([
             42551, 29164, 21013, 20151, 44157, 25636, 59364, 61542, 49967, 15147, 57085, 44552,
@@ -20084,7 +20084,7 @@ fn test_containers_var_test_struct_random_8() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x84bef9b1a73afced6bee012877fdb48c4aa6fe6d04abe017f751694eef538871");
     assert_eq!(root, expected_root);
@@ -20092,7 +20092,7 @@ fn test_containers_var_test_struct_random_8() {
 
 #[test]
 fn test_containers_var_test_struct_random_9() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 10642,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([
             54718, 63609, 42996, 4237, 51836, 49123, 55803, 62568, 48996, 39224, 10120, 2400,
@@ -20121,7 +20121,7 @@ fn test_containers_var_test_struct_random_9() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x87f0a7aa36ee9495cff11dbc34a49df4aff53a34b5b1d117737b6297600034a8");
     assert_eq!(root, expected_root);
@@ -20129,7 +20129,7 @@ fn test_containers_var_test_struct_random_9() {
 
 #[test]
 fn test_containers_var_test_struct_random_chaos_0() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 61327,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([
             48055, 8544, 0, 43486, 65535, 65535, 65535, 43330, 38506, 25502, 36573, 26738, 65535,
@@ -20221,7 +20221,7 @@ fn test_containers_var_test_struct_random_chaos_0() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x848cbb400c84bed5e4e210776c75894ff0c0f8d6058e9b6b30399d9174f61ee4");
     assert_eq!(root, expected_root);
@@ -20229,7 +20229,7 @@ fn test_containers_var_test_struct_random_chaos_0() {
 
 #[test]
 fn test_containers_var_test_struct_random_chaos_1() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 57484,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([
             57695, 21309, 65535, 36350, 38811, 1214, 0, 65535, 65535, 51370, 6760, 0, 128, 26614,
@@ -20248,7 +20248,7 @@ fn test_containers_var_test_struct_random_chaos_1() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf9e1edc08d6a8666c941982ca4fc444ba36e4cebab7b35a7ab4568e78427235b");
     assert_eq!(root, expected_root);
@@ -20256,7 +20256,7 @@ fn test_containers_var_test_struct_random_chaos_1() {
 
 #[test]
 fn test_containers_var_test_struct_random_chaos_2() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 22342,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([40410])).unwrap(),
         c: 151,
@@ -20270,7 +20270,7 @@ fn test_containers_var_test_struct_random_chaos_2() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x96fd92859ccf7ed5cecea85dc34c4a56fd99ff02bab864cfef5c138efe9f187d");
     assert_eq!(root, expected_root);
@@ -20302,7 +20302,7 @@ fn test_containers_var_test_struct_random_offset_2_zeroed() {
 
 #[test]
 fn test_containers_var_test_struct_zero() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 0,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -20351,7 +20351,7 @@ fn test_containers_var_test_struct_zero() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x16acbeea0d56bf42f89e617952156532bc11ef5ec02054964d827ae524bd9356");
     assert_eq!(root, expected_root);
@@ -20359,7 +20359,7 @@ fn test_containers_var_test_struct_zero() {
 
 #[test]
 fn test_containers_var_test_struct_zero_0() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 0,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -20378,7 +20378,7 @@ fn test_containers_var_test_struct_zero_0() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x2c871e8c0540811d51f15de23d73717fc2a929dec0fda436be955d7cf2f3df9d");
     assert_eq!(root, expected_root);
@@ -20386,7 +20386,7 @@ fn test_containers_var_test_struct_zero_0() {
 
 #[test]
 fn test_containers_var_test_struct_zero_1() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 0,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -20432,7 +20432,7 @@ fn test_containers_var_test_struct_zero_1() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x2af7038b882598953c563fe437767e0df6418ac184c3dedd82a790f42306db53");
     assert_eq!(root, expected_root);
@@ -20440,7 +20440,7 @@ fn test_containers_var_test_struct_zero_1() {
 
 #[test]
 fn test_containers_var_test_struct_zero_2() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 0,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -20487,7 +20487,7 @@ fn test_containers_var_test_struct_zero_2() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xd8817199ad16ef7defe2ebe7eed43e875d3190444975a212c29032255783e892");
     assert_eq!(root, expected_root);
@@ -20495,7 +20495,7 @@ fn test_containers_var_test_struct_zero_2() {
 
 #[test]
 fn test_containers_var_test_struct_zero_3() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 0,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -20517,7 +20517,7 @@ fn test_containers_var_test_struct_zero_3() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x2fec69323cd5e304fab170b42dbedd74ea45eafcce0e0ea7b786e0c127237c44");
     assert_eq!(root, expected_root);
@@ -20525,7 +20525,7 @@ fn test_containers_var_test_struct_zero_3() {
 
 #[test]
 fn test_containers_var_test_struct_zero_4() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 0,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -20543,7 +20543,7 @@ fn test_containers_var_test_struct_zero_4() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xb0c8e63107347f4d1c70b4f6aff92840432065befc84a8c0a79d0e50e65fb0cf");
     assert_eq!(root, expected_root);
@@ -20551,7 +20551,7 @@ fn test_containers_var_test_struct_zero_4() {
 
 #[test]
 fn test_containers_var_test_struct_zero_5() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 0,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -20594,7 +20594,7 @@ fn test_containers_var_test_struct_zero_5() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xe5f19c1bb9eed4f20d95ff6205e1b4cc884207a99ff6d06f61b4fc7a68a362da");
     assert_eq!(root, expected_root);
@@ -20602,7 +20602,7 @@ fn test_containers_var_test_struct_zero_5() {
 
 #[test]
 fn test_containers_var_test_struct_zero_6() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 0,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -20647,7 +20647,7 @@ fn test_containers_var_test_struct_zero_6() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x2234142ef7bd4660edcd29578f9308d36d3c3cbc87e769c64a391b1f6cf52bca");
     assert_eq!(root, expected_root);
@@ -20655,7 +20655,7 @@ fn test_containers_var_test_struct_zero_6() {
 
 #[test]
 fn test_containers_var_test_struct_zero_7() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 0,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -20706,7 +20706,7 @@ fn test_containers_var_test_struct_zero_7() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x09e5ca8868427972a8491f46951fb2c508b2f3dd5ce3fdb550be256dbd959477");
     assert_eq!(root, expected_root);
@@ -20714,7 +20714,7 @@ fn test_containers_var_test_struct_zero_7() {
 
 #[test]
 fn test_containers_var_test_struct_zero_8() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 0,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -20749,7 +20749,7 @@ fn test_containers_var_test_struct_zero_8() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xb5db5710ba6f6237071537b206aa4c78616410315b54507ae5e835a70b52ffcd");
     assert_eq!(root, expected_root);
@@ -20757,7 +20757,7 @@ fn test_containers_var_test_struct_zero_8() {
 
 #[test]
 fn test_containers_var_test_struct_zero_9() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 0,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -20794,7 +20794,7 @@ fn test_containers_var_test_struct_zero_9() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x3435d4b16347c2f0f695680b96bbf19e7026196ab96bc9fb96f9d35b954cba51");
     assert_eq!(root, expected_root);
@@ -20802,7 +20802,7 @@ fn test_containers_var_test_struct_zero_9() {
 
 #[test]
 fn test_containers_var_test_struct_zero_chaos_0() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 30711,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([
             728, 55064, 35225, 37227, 9777, 65535, 21575, 59226, 0, 38436, 65535, 65535, 65535,
@@ -20866,7 +20866,7 @@ fn test_containers_var_test_struct_zero_chaos_0() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xd772e661be2b3fcd82c2bf7a4351073a3f54305159d70dc2f2e6c9099cf85e22");
     assert_eq!(root, expected_root);
@@ -20874,7 +20874,7 @@ fn test_containers_var_test_struct_zero_chaos_0() {
 
 #[test]
 fn test_containers_var_test_struct_zero_chaos_1() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 24501,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([
             65535, 20397, 900, 1821, 41061, 47857, 0, 38153, 0, 40001, 20908, 16043, 53524, 32823,
@@ -20965,7 +20965,7 @@ fn test_containers_var_test_struct_zero_chaos_1() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x7fbb2d2fde27c7a3135a7e9b312987d3633ee8b4d23c8b4c8b56c4088d0290ab");
     assert_eq!(root, expected_root);
@@ -20973,7 +20973,7 @@ fn test_containers_var_test_struct_zero_chaos_1() {
 
 #[test]
 fn test_containers_var_test_struct_zero_chaos_2() {
-    let mut value = VarTestStruct {
+    let value = VarTestStruct {
         a: 0,
         b: List::<u16, 1024>::try_from(Vec::<u16>::from_iter([
             0, 63908, 4719, 0, 65535, 31561, 63902, 43408, 0, 0, 43171, 2965, 37781, 65535, 3809,
@@ -21046,7 +21046,7 @@ fn test_containers_var_test_struct_zero_chaos_2() {
     let recovered_value: VarTestStruct = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x6147fa8c73be30da574a1b8a983141ae0986c0ec6d1a5cc63bf164a87f1667a5");
     assert_eq!(root, expected_root);

--- a/ssz-rs/tests/test_utils.rs
+++ b/ssz-rs/tests/test_utils.rs
@@ -14,7 +14,7 @@ pub fn deserialize<T: SimpleSerialize>(encoding: &[u8]) -> T {
     ssz_rs::deserialize(encoding).expect("can deserialize")
 }
 
-pub fn hash_tree_root<T: SimpleSerialize>(value: &mut T) -> Node {
+pub fn hash_tree_root<T: SimpleSerialize>(value: &T) -> Node {
     value.hash_tree_root().expect("can compute root")
 }
 

--- a/ssz-rs/tests/uints.rs
+++ b/ssz-rs/tests/uints.rs
@@ -8,7 +8,7 @@ use test_utils::{
 
 #[test]
 fn test_uints_uint_128_last_byte_empty() {
-    let mut value = 1329227995784915872903807060280344575;
+    let value = 1329227995784915872903807060280344575;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/uints/valid/uint_128_last_byte_empty/serialized.ssz_snappy",
@@ -18,7 +18,7 @@ fn test_uints_uint_128_last_byte_empty() {
     let recovered_value: u128 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xffffffffffffffffffffffffffffff0000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -26,7 +26,7 @@ fn test_uints_uint_128_last_byte_empty() {
 
 #[test]
 fn test_uints_uint_128_max() {
-    let mut value = 340282366920938463463374607431768211455;
+    let value = 340282366920938463463374607431768211455;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/uints/valid/uint_128_max/serialized.ssz_snappy",
@@ -36,7 +36,7 @@ fn test_uints_uint_128_max() {
     let recovered_value: u128 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xffffffffffffffffffffffffffffffff00000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -74,7 +74,7 @@ fn test_uints_uint_128_one_too_high() {
 
 #[test]
 fn test_uints_uint_128_random_0() {
-    let mut value = 317658863013703600909281237913711302754;
+    let value = 317658863013703600909281237913711302754;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/uints/valid/uint_128_random_0/serialized.ssz_snappy",
@@ -84,7 +84,7 @@ fn test_uints_uint_128_random_0() {
     let recovered_value: u128 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x62583644e66ec83fc2a6cda723dffaee00000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -92,7 +92,7 @@ fn test_uints_uint_128_random_0() {
 
 #[test]
 fn test_uints_uint_128_random_1() {
-    let mut value = 226427817519480008631815531407103573168;
+    let value = 226427817519480008631815531407103573168;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/uints/valid/uint_128_random_1/serialized.ssz_snappy",
@@ -102,7 +102,7 @@ fn test_uints_uint_128_random_1() {
     let recovered_value: u128 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xb03c1174ebe365e018a5b887516958aa00000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -110,7 +110,7 @@ fn test_uints_uint_128_random_1() {
 
 #[test]
 fn test_uints_uint_128_random_2() {
-    let mut value = 1966913376797472348559631900882537126;
+    let value = 1966913376797472348559631900882537126;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/uints/valid/uint_128_random_2/serialized.ssz_snappy",
@@ -120,7 +120,7 @@ fn test_uints_uint_128_random_2() {
     let recovered_value: u128 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xa68a04f1c6f71282ca13121251d07a0100000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -128,7 +128,7 @@ fn test_uints_uint_128_random_2() {
 
 #[test]
 fn test_uints_uint_128_random_3() {
-    let mut value = 223686144064414504608552983434269426145;
+    let value = 223686144064414504608552983434269426145;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/uints/valid/uint_128_random_3/serialized.ssz_snappy",
@@ -138,7 +138,7 @@ fn test_uints_uint_128_random_3() {
     let recovered_value: u128 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xe101ce24c16ec3b57c2f0b79616248a800000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -146,7 +146,7 @@ fn test_uints_uint_128_random_3() {
 
 #[test]
 fn test_uints_uint_128_random_4() {
-    let mut value = 199925590919705556758473559487562637786;
+    let value = 199925590919705556758473559487562637786;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/uints/valid/uint_128_random_4/serialized.ssz_snappy",
@@ -156,7 +156,7 @@ fn test_uints_uint_128_random_4() {
     let recovered_value: u128 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xdae1c72a086dde0deb118413aa44689600000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -164,7 +164,7 @@ fn test_uints_uint_128_random_4() {
 
 #[test]
 fn test_uints_uint_128_zero() {
-    let mut value = 0;
+    let value = 0;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/uints/valid/uint_128_zero/serialized.ssz_snappy",
@@ -174,7 +174,7 @@ fn test_uints_uint_128_zero() {
     let recovered_value: u128 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -182,7 +182,7 @@ fn test_uints_uint_128_zero() {
 
 #[test]
 fn test_uints_uint_16_last_byte_empty() {
-    let mut value = 255;
+    let value = 255;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/uints/valid/uint_16_last_byte_empty/serialized.ssz_snappy",
@@ -192,7 +192,7 @@ fn test_uints_uint_16_last_byte_empty() {
     let recovered_value: u16 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xff00000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -200,7 +200,7 @@ fn test_uints_uint_16_last_byte_empty() {
 
 #[test]
 fn test_uints_uint_16_max() {
-    let mut value = 65535;
+    let value = 65535;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/uints/valid/uint_16_max/serialized.ssz_snappy",
@@ -210,7 +210,7 @@ fn test_uints_uint_16_max() {
     let recovered_value: u16 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xffff000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -248,7 +248,7 @@ fn test_uints_uint_16_one_too_high() {
 
 #[test]
 fn test_uints_uint_16_random_0() {
-    let mut value = 11001;
+    let value = 11001;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/uints/valid/uint_16_random_0/serialized.ssz_snappy",
@@ -258,7 +258,7 @@ fn test_uints_uint_16_random_0() {
     let recovered_value: u16 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xf92a000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -266,7 +266,7 @@ fn test_uints_uint_16_random_0() {
 
 #[test]
 fn test_uints_uint_16_random_1() {
-    let mut value = 12900;
+    let value = 12900;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/uints/valid/uint_16_random_1/serialized.ssz_snappy",
@@ -276,7 +276,7 @@ fn test_uints_uint_16_random_1() {
     let recovered_value: u16 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x6432000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -284,7 +284,7 @@ fn test_uints_uint_16_random_1() {
 
 #[test]
 fn test_uints_uint_16_random_2() {
-    let mut value = 46482;
+    let value = 46482;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/uints/valid/uint_16_random_2/serialized.ssz_snappy",
@@ -294,7 +294,7 @@ fn test_uints_uint_16_random_2() {
     let recovered_value: u16 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x92b5000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -302,7 +302,7 @@ fn test_uints_uint_16_random_2() {
 
 #[test]
 fn test_uints_uint_16_random_3() {
-    let mut value = 31039;
+    let value = 31039;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/uints/valid/uint_16_random_3/serialized.ssz_snappy",
@@ -312,7 +312,7 @@ fn test_uints_uint_16_random_3() {
     let recovered_value: u16 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x3f79000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -320,7 +320,7 @@ fn test_uints_uint_16_random_3() {
 
 #[test]
 fn test_uints_uint_16_random_4() {
-    let mut value = 2284;
+    let value = 2284;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/uints/valid/uint_16_random_4/serialized.ssz_snappy",
@@ -330,7 +330,7 @@ fn test_uints_uint_16_random_4() {
     let recovered_value: u16 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xec08000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -338,7 +338,7 @@ fn test_uints_uint_16_random_4() {
 
 #[test]
 fn test_uints_uint_16_zero() {
-    let mut value = 0;
+    let value = 0;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/uints/valid/uint_16_zero/serialized.ssz_snappy",
@@ -348,7 +348,7 @@ fn test_uints_uint_16_zero() {
     let recovered_value: u16 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -356,7 +356,7 @@ fn test_uints_uint_16_zero() {
 
 #[test]
 fn test_uints_uint_256_last_byte_empty() {
-    let mut value = U256::try_from_le_slice(
+    let value = U256::try_from_le_slice(
         Vec::<u8>::from_iter([
             255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
             255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 0,
@@ -373,7 +373,7 @@ fn test_uints_uint_256_last_byte_empty() {
     let recovered_value: U256 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00");
     assert_eq!(root, expected_root);
@@ -381,7 +381,7 @@ fn test_uints_uint_256_last_byte_empty() {
 
 #[test]
 fn test_uints_uint_256_max() {
-    let mut value = U256::try_from_le_slice(
+    let value = U256::try_from_le_slice(
         Vec::<u8>::from_iter([
             255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
             255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
@@ -398,7 +398,7 @@ fn test_uints_uint_256_max() {
     let recovered_value: U256 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
     assert_eq!(root, expected_root);
@@ -436,7 +436,7 @@ fn test_uints_uint_256_one_too_high() {
 
 #[test]
 fn test_uints_uint_256_random_0() {
-    let mut value = U256::try_from_le_slice(
+    let value = U256::try_from_le_slice(
         Vec::<u8>::from_iter([
             58, 55, 99, 28, 168, 145, 249, 244, 255, 81, 153, 135, 170, 128, 39, 36, 202, 1, 166,
             171, 97, 55, 46, 78, 36, 161, 66, 116, 168, 139, 34, 10,
@@ -453,7 +453,7 @@ fn test_uints_uint_256_random_0() {
     let recovered_value: U256 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x3a37631ca891f9f4ff519987aa802724ca01a6ab61372e4e24a14274a88b220a");
     assert_eq!(root, expected_root);
@@ -461,7 +461,7 @@ fn test_uints_uint_256_random_0() {
 
 #[test]
 fn test_uints_uint_256_random_1() {
-    let mut value = U256::try_from_le_slice(
+    let value = U256::try_from_le_slice(
         Vec::<u8>::from_iter([
             160, 200, 243, 199, 115, 30, 235, 132, 127, 224, 146, 208, 192, 97, 24, 112, 2, 157,
             177, 75, 95, 22, 105, 70, 180, 97, 182, 31, 39, 79, 21, 199,
@@ -478,7 +478,7 @@ fn test_uints_uint_256_random_1() {
     let recovered_value: U256 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xa0c8f3c7731eeb847fe092d0c0611870029db14b5f166946b461b61f274f15c7");
     assert_eq!(root, expected_root);
@@ -486,7 +486,7 @@ fn test_uints_uint_256_random_1() {
 
 #[test]
 fn test_uints_uint_256_random_2() {
-    let mut value = U256::try_from_le_slice(
+    let value = U256::try_from_le_slice(
         Vec::<u8>::from_iter([
             145, 36, 54, 124, 134, 65, 119, 96, 224, 3, 87, 209, 164, 118, 23, 209, 5, 72, 9, 168,
             251, 195, 102, 65, 122, 101, 27, 164, 66, 115, 0, 49,
@@ -503,7 +503,7 @@ fn test_uints_uint_256_random_2() {
     let recovered_value: U256 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x9124367c86417760e00357d1a47617d1054809a8fbc366417a651ba442730031");
     assert_eq!(root, expected_root);
@@ -511,7 +511,7 @@ fn test_uints_uint_256_random_2() {
 
 #[test]
 fn test_uints_uint_256_random_3() {
-    let mut value = U256::try_from_le_slice(
+    let value = U256::try_from_le_slice(
         Vec::<u8>::from_iter([
             9, 220, 230, 65, 45, 6, 68, 219, 208, 26, 176, 18, 183, 94, 87, 176, 157, 70, 34, 109,
             52, 201, 18, 243, 217, 129, 175, 51, 196, 80, 238, 25,
@@ -528,7 +528,7 @@ fn test_uints_uint_256_random_3() {
     let recovered_value: U256 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x09dce6412d0644dbd01ab012b75e57b09d46226d34c912f3d981af33c450ee19");
     assert_eq!(root, expected_root);
@@ -536,7 +536,7 @@ fn test_uints_uint_256_random_3() {
 
 #[test]
 fn test_uints_uint_256_random_4() {
-    let mut value = U256::try_from_le_slice(
+    let value = U256::try_from_le_slice(
         Vec::<u8>::from_iter([
             236, 44, 123, 92, 134, 169, 87, 238, 98, 219, 210, 219, 26, 37, 128, 52, 156, 71, 217,
             131, 206, 187, 193, 227, 34, 128, 209, 179, 17, 9, 210, 107,
@@ -553,7 +553,7 @@ fn test_uints_uint_256_random_4() {
     let recovered_value: U256 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xec2c7b5c86a957ee62dbd2db1a2580349c47d983cebbc1e32280d1b31109d26b");
     assert_eq!(root, expected_root);
@@ -561,7 +561,7 @@ fn test_uints_uint_256_random_4() {
 
 #[test]
 fn test_uints_uint_256_zero() {
-    let mut value = U256::try_from_le_slice(
+    let value = U256::try_from_le_slice(
         Vec::<u8>::from_iter([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0,
@@ -578,7 +578,7 @@ fn test_uints_uint_256_zero() {
     let recovered_value: U256 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -586,7 +586,7 @@ fn test_uints_uint_256_zero() {
 
 #[test]
 fn test_uints_uint_32_last_byte_empty() {
-    let mut value = 16777215;
+    let value = 16777215;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/uints/valid/uint_32_last_byte_empty/serialized.ssz_snappy",
@@ -596,7 +596,7 @@ fn test_uints_uint_32_last_byte_empty() {
     let recovered_value: u32 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xffffff0000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -604,7 +604,7 @@ fn test_uints_uint_32_last_byte_empty() {
 
 #[test]
 fn test_uints_uint_32_max() {
-    let mut value = 4294967295;
+    let value = 4294967295;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/uints/valid/uint_32_max/serialized.ssz_snappy",
@@ -614,7 +614,7 @@ fn test_uints_uint_32_max() {
     let recovered_value: u32 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xffffffff00000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -652,7 +652,7 @@ fn test_uints_uint_32_one_too_high() {
 
 #[test]
 fn test_uints_uint_32_random_0() {
-    let mut value = 3387753032;
+    let value = 3387753032;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/uints/valid/uint_32_random_0/serialized.ssz_snappy",
@@ -662,7 +662,7 @@ fn test_uints_uint_32_random_0() {
     let recovered_value: u32 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x4802edc900000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -670,7 +670,7 @@ fn test_uints_uint_32_random_0() {
 
 #[test]
 fn test_uints_uint_32_random_1() {
-    let mut value = 2676973563;
+    let value = 2676973563;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/uints/valid/uint_32_random_1/serialized.ssz_snappy",
@@ -680,7 +680,7 @@ fn test_uints_uint_32_random_1() {
     let recovered_value: u32 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xfb5f8f9f00000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -688,7 +688,7 @@ fn test_uints_uint_32_random_1() {
 
 #[test]
 fn test_uints_uint_32_random_2() {
-    let mut value = 2644908285;
+    let value = 2644908285;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/uints/valid/uint_32_random_2/serialized.ssz_snappy",
@@ -698,7 +698,7 @@ fn test_uints_uint_32_random_2() {
     let recovered_value: u32 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xfd18a69d00000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -706,7 +706,7 @@ fn test_uints_uint_32_random_2() {
 
 #[test]
 fn test_uints_uint_32_random_3() {
-    let mut value = 638037343;
+    let value = 638037343;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/uints/valid/uint_32_random_3/serialized.ssz_snappy",
@@ -716,7 +716,7 @@ fn test_uints_uint_32_random_3() {
     let recovered_value: u32 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x5fad072600000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -724,7 +724,7 @@ fn test_uints_uint_32_random_3() {
 
 #[test]
 fn test_uints_uint_32_random_4() {
-    let mut value = 4144220671;
+    let value = 4144220671;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/uints/valid/uint_32_random_4/serialized.ssz_snappy",
@@ -734,7 +734,7 @@ fn test_uints_uint_32_random_4() {
     let recovered_value: u32 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xffc903f700000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -742,7 +742,7 @@ fn test_uints_uint_32_random_4() {
 
 #[test]
 fn test_uints_uint_32_zero() {
-    let mut value = 0;
+    let value = 0;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/uints/valid/uint_32_zero/serialized.ssz_snappy",
@@ -752,7 +752,7 @@ fn test_uints_uint_32_zero() {
     let recovered_value: u32 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -760,7 +760,7 @@ fn test_uints_uint_32_zero() {
 
 #[test]
 fn test_uints_uint_64_last_byte_empty() {
-    let mut value = 72057594037927935;
+    let value = 72057594037927935;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/uints/valid/uint_64_last_byte_empty/serialized.ssz_snappy",
@@ -770,7 +770,7 @@ fn test_uints_uint_64_last_byte_empty() {
     let recovered_value: u64 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xffffffffffffff00000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -778,7 +778,7 @@ fn test_uints_uint_64_last_byte_empty() {
 
 #[test]
 fn test_uints_uint_64_max() {
-    let mut value = 18446744073709551615;
+    let value = 18446744073709551615;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/uints/valid/uint_64_max/serialized.ssz_snappy",
@@ -788,7 +788,7 @@ fn test_uints_uint_64_max() {
     let recovered_value: u64 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xffffffffffffffff000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -826,7 +826,7 @@ fn test_uints_uint_64_one_too_high() {
 
 #[test]
 fn test_uints_uint_64_random_0() {
-    let mut value = 8594311575614880821;
+    let value = 8594311575614880821;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/uints/valid/uint_64_random_0/serialized.ssz_snappy",
@@ -836,7 +836,7 @@ fn test_uints_uint_64_random_0() {
     let recovered_value: u64 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x357c8de9d7204577000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -844,7 +844,7 @@ fn test_uints_uint_64_random_0() {
 
 #[test]
 fn test_uints_uint_64_random_1() {
-    let mut value = 12453893770581738044;
+    let value = 12453893770581738044;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/uints/valid/uint_64_random_1/serialized.ssz_snappy",
@@ -854,7 +854,7 @@ fn test_uints_uint_64_random_1() {
     let recovered_value: u64 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x3c82f999661ed5ac000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -862,7 +862,7 @@ fn test_uints_uint_64_random_1() {
 
 #[test]
 fn test_uints_uint_64_random_2() {
-    let mut value = 10680714365983390887;
+    let value = 10680714365983390887;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/uints/valid/uint_64_random_2/serialized.ssz_snappy",
@@ -872,7 +872,7 @@ fn test_uints_uint_64_random_2() {
     let recovered_value: u64 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xa7fcd98320853994000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -880,7 +880,7 @@ fn test_uints_uint_64_random_2() {
 
 #[test]
 fn test_uints_uint_64_random_3() {
-    let mut value = 11891402719218752485;
+    let value = 11891402719218752485;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/uints/valid/uint_64_random_3/serialized.ssz_snappy",
@@ -890,7 +890,7 @@ fn test_uints_uint_64_random_3() {
     let recovered_value: u64 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xe5db2510c5bf06a5000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -898,7 +898,7 @@ fn test_uints_uint_64_random_3() {
 
 #[test]
 fn test_uints_uint_64_random_4() {
-    let mut value = 15683022699148686111;
+    let value = 15683022699148686111;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/uints/valid/uint_64_random_4/serialized.ssz_snappy",
@@ -908,7 +908,7 @@ fn test_uints_uint_64_random_4() {
     let recovered_value: u64 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x1f33257b0d4aa5d9000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -916,7 +916,7 @@ fn test_uints_uint_64_random_4() {
 
 #[test]
 fn test_uints_uint_64_zero() {
-    let mut value = 0;
+    let value = 0;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/uints/valid/uint_64_zero/serialized.ssz_snappy",
@@ -926,7 +926,7 @@ fn test_uints_uint_64_zero() {
     let recovered_value: u64 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -934,7 +934,7 @@ fn test_uints_uint_64_zero() {
 
 #[test]
 fn test_uints_uint_8_last_byte_empty() {
-    let mut value = 0;
+    let value = 0;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/uints/valid/uint_8_last_byte_empty/serialized.ssz_snappy",
@@ -944,7 +944,7 @@ fn test_uints_uint_8_last_byte_empty() {
     let recovered_value: u8 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -952,7 +952,7 @@ fn test_uints_uint_8_last_byte_empty() {
 
 #[test]
 fn test_uints_uint_8_max() {
-    let mut value = 255;
+    let value = 255;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/uints/valid/uint_8_max/serialized.ssz_snappy",
@@ -962,7 +962,7 @@ fn test_uints_uint_8_max() {
     let recovered_value: u8 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xff00000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -1000,7 +1000,7 @@ fn test_uints_uint_8_one_too_high() {
 
 #[test]
 fn test_uints_uint_8_random_0() {
-    let mut value = 225;
+    let value = 225;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/uints/valid/uint_8_random_0/serialized.ssz_snappy",
@@ -1010,7 +1010,7 @@ fn test_uints_uint_8_random_0() {
     let recovered_value: u8 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0xe100000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -1018,7 +1018,7 @@ fn test_uints_uint_8_random_0() {
 
 #[test]
 fn test_uints_uint_8_random_1() {
-    let mut value = 59;
+    let value = 59;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/uints/valid/uint_8_random_1/serialized.ssz_snappy",
@@ -1028,7 +1028,7 @@ fn test_uints_uint_8_random_1() {
     let recovered_value: u8 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x3b00000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -1036,7 +1036,7 @@ fn test_uints_uint_8_random_1() {
 
 #[test]
 fn test_uints_uint_8_random_2() {
-    let mut value = 3;
+    let value = 3;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/uints/valid/uint_8_random_2/serialized.ssz_snappy",
@@ -1046,7 +1046,7 @@ fn test_uints_uint_8_random_2() {
     let recovered_value: u8 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0300000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -1054,7 +1054,7 @@ fn test_uints_uint_8_random_2() {
 
 #[test]
 fn test_uints_uint_8_random_3() {
-    let mut value = 46;
+    let value = 46;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/uints/valid/uint_8_random_3/serialized.ssz_snappy",
@@ -1064,7 +1064,7 @@ fn test_uints_uint_8_random_3() {
     let recovered_value: u8 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x2e00000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -1072,7 +1072,7 @@ fn test_uints_uint_8_random_3() {
 
 #[test]
 fn test_uints_uint_8_random_4() {
-    let mut value = 17;
+    let value = 17;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/uints/valid/uint_8_random_4/serialized.ssz_snappy",
@@ -1082,7 +1082,7 @@ fn test_uints_uint_8_random_4() {
     let recovered_value: u8 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x1100000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);
@@ -1090,7 +1090,7 @@ fn test_uints_uint_8_random_4() {
 
 #[test]
 fn test_uints_uint_8_zero() {
-    let mut value = 0;
+    let value = 0;
     let encoding = serialize(&value);
     let expected_encoding = read_ssz_snappy_from_test_data(
         "ssz-rs/tests/data/uints/valid/uint_8_zero/serialized.ssz_snappy",
@@ -1100,7 +1100,7 @@ fn test_uints_uint_8_zero() {
     let recovered_value: u8 = deserialize(&expected_encoding);
     assert_eq!(recovered_value, value);
 
-    let root = hash_tree_root(&mut value);
+    let root = hash_tree_root(&value);
     let expected_root =
         root_from_hex("0x0000000000000000000000000000000000000000000000000000000000000000");
     assert_eq!(root, expected_root);


### PR DESCRIPTION
this was originally left `mut` to facilitate caching of the Merkle tree,
but given it is a big ask in Rust, let's drop it and make the resulting
simplifications