### PR TITLE
`sha2-asm` feature

### DIFF
--- a/ssz-rs/Cargo.toml
+++ b/ssz-rs/Cargo.toml
@@ -20,7 +20,7 @@ serde = ["dep:serde", "alloy-primitives/serde"]
 [dependencies]
 bitvec = { version = "1.0.0", default-features = false, features = ["alloc"] }
 ssz_rs_derive = { path = "../ssz-rs-derive", version = "0.9.0" }
-sha2 = { version = "0.9.8", default-features = false, features = ["asm"] }
+sha2 = { version = "0.9.8", default-features = false }
 serde = { version = "1.0", default-features = false, features = [
     "alloc",
     "derive",

--- a/ssz-rs/Cargo.toml
+++ b/ssz-rs/Cargo.toml
@@ -14,12 +14,13 @@ exclude = ["tests/data"]
 [features]
 default = ["serde", "std"]
 std = ["bitvec/default", "sha2/default", "alloy-primitives/default"]
+sha2-asm = ["sha2/asm"]
 serde = ["dep:serde", "alloy-primitives/serde"]
 
 [dependencies]
 bitvec = { version = "1.0.0", default-features = false, features = ["alloc"] }
 ssz_rs_derive = { path = "../ssz-rs-derive", version = "0.9.0" }
-sha2 = { version = "0.9.8", default-features = false }
+sha2 = { version = "0.9.8", default-features = false, features = ["asm"] }
 serde = { version = "1.0", default-features = false, features = [
     "alloc",
     "derive",

--- a/ssz-rs/src/merkleization/proofs.rs
+++ b/ssz-rs/src/merkleization/proofs.rs
@@ -207,7 +207,7 @@ pub fn is_valid_merkle_branch(
     root: Node,
 ) -> Result<(), Error> {
     if branch.len() != depth {
-        return Err(Error::InvalidProof)
+        return Err(Error::InvalidProof);
     }
 
     let mut derived_root = leaf;
@@ -293,6 +293,34 @@ pub(crate) mod tests {
         );
         let result = proof.verify(root);
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_list_proving() {
+        let inner: Vec<List<u8, 1073741824>> = vec![
+            vec![0u8, 1u8, 2u8].try_into().unwrap(),
+            vec![3u8, 4u8, 5u8].try_into().unwrap(),
+            vec![6u8, 7u8, 8u8].try_into().unwrap(),
+            vec![9u8, 10u8, 11u8].try_into().unwrap(),
+        ];
+
+        // Emulate a transactions tree
+        let outer: List<List<u8, 1073741824>, 1048576> = List::try_from(inner).unwrap();
+
+        let root = outer.hash_tree_root().unwrap();
+
+        let index = PathElement::from(1);
+
+        let start_proof = std::time::Instant::now();
+        let (proof, witness) = outer.prove(&[index]).unwrap();
+        println!("Generated proof in {:?}", start_proof.elapsed());
+
+        // Root and witness must be the same
+        assert_eq!(root, witness);
+
+        let start_verify = std::time::Instant::now();
+        assert!(proof.verify(witness).is_ok());
+        println!("Verified proof in {:?}", start_verify.elapsed());
     }
 
     #[test]

--- a/ssz-rs/src/merkleization/proofs.rs
+++ b/ssz-rs/src/merkleization/proofs.rs
@@ -207,7 +207,7 @@ pub fn is_valid_merkle_branch(
     root: Node,
 ) -> Result<(), Error> {
     if branch.len() != depth {
-        return Err(Error::InvalidProof);
+        return Err(Error::InvalidProof)
     }
 
     let mut derived_root = leaf;


### PR DESCRIPTION
## Context
This PR implements a feature for enabling the `asm` feature on the `sha2` crate. When testing against a real world payload (generate a proof of transaction inclusion against the transactions root), these are the numbers:

- `sha2-asm` feature disabled:
```
Transactions root: 0x3834068daa909f5553bd06299dc60ccd43fa2c24da3778dda30b6c7fc767f240, num transactions: 129
Index to prove: 26
Generated proof in 855.763416ms
Verified proof in 9.708µs
```
- `sha2-asm` feature enabled:
```
Transactions root: 0x3834068daa909f5553bd06299dc60ccd43fa2c24da3778dda30b6c7fc767f240, num transactions: 129
Index to prove: 26
Generated proof in 133.917375ms
Verified proof in 1.917µs
```

## Conclusion
With `sha2-asm` enabled, proof generation becomes around 6,5 times faster.