### PR TITLE
Use memory-efficient Merkle Tree computation when generating proofs. 

### DIFF
--- a/ssz-rs/src/merkleization/merkleize.rs
+++ b/ssz-rs/src/merkleization/merkleize.rs
@@ -162,9 +162,9 @@ impl Tree {
     /// `chunks` forms the bottom layer of this tree.
     ///
     /// This implementation is memory efficient by relying on pre-computed subtrees of all
-    /// "zero" leaves stored in the `CONTEXT`. SSZ specifies that `chunks` is padded to the next power
-    /// of two and this can be quite large for some types. "Zero" subtrees are virtualized to avoid the
-    /// memory and computation cost of large trees with partially empty leaves.
+    /// "zero" leaves stored in the `CONTEXT`. SSZ specifies that `chunks` is padded to the next
+    /// power of two and this can be quite large for some types. "Zero" subtrees are virtualized
+    /// to avoid the memory and computation cost of large trees with partially empty leaves.
     ///
     /// The implementation approach treats `chunks` as the bottom layer of a perfect binary tree
     /// and for each height performs the hashing required to compute the parent layer in place.


### PR DESCRIPTION
I modified the `Tree` so it virtualizes empty nodes, this way it only stores the actual value nodes. I also refactored `merkleize_chunks_with_virtual_padding` and added it inside the `Tree` so we can utilize it. Fixes #163 