### PR TITLE
feat: bump msrv & alloy version

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.70.0"
+channel = "1.79.0"

--- a/ssz-rs/Cargo.toml
+++ b/ssz-rs/Cargo.toml
@@ -25,7 +25,7 @@ serde = { version = "1.0", default-features = false, features = [
     "alloc",
     "derive",
 ], optional = true }
-alloy-primitives = { version = "~0.7", default-features = false }
+alloy-primitives = { version = "~0.8", default-features = false }
 
 [dev-dependencies]
 snap = "1.0"


### PR DESCRIPTION
Bumped alloy-primitives to ~0.8, which required an update to MSRV (1.79)