### PR TITLE
feat: add hash_tree_root() bench

### DIFF
--- a/ssz-rs/Cargo.toml
+++ b/ssz-rs/Cargo.toml
@@ -32,6 +32,11 @@ snap = "1.0"
 project-root = "0.2.2"
 serde_json = "1.0.81"
 hex = "0.4.3"
+criterion = { version = "0.5", features = ["html_reports"] }
 
 [build-dependencies]
 sha2 = "0.9.8"
+
+[[bench]]
+name = "merkleization"
+harness = false

--- a/ssz-rs/benches/merkleization.rs
+++ b/ssz-rs/benches/merkleization.rs
@@ -1,0 +1,25 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use std::hint::black_box;
+
+fn bench_merkleization(c: &mut Criterion) {
+    use ssz_rs::{HashTreeRoot, List};
+
+    let inner: Vec<List<u8, 1073741824>> = vec![
+        vec![0u8, 1u8, 2u8].try_into().unwrap(),
+        vec![3u8, 4u8, 5u8].try_into().unwrap(),
+        vec![6u8, 7u8, 8u8].try_into().unwrap(),
+        vec![9u8, 10u8, 11u8].try_into().unwrap(),
+    ];
+
+    // Emulate a transactions tree
+    let outer: List<List<u8, 1073741824>, 1048576> = List::try_from(inner).unwrap();
+
+    c.bench_function("hash_tree_root", |b| {
+        b.iter(|| {
+            let _ = black_box(outer.hash_tree_root().unwrap());
+        })
+    });
+}
+
+criterion_group!(benches, bench_merkleization);
+criterion_main!(benches);


### PR DESCRIPTION
First PR in a series to improve the performance of `hash_tree_root()`

This work will eventually supersede https://github.com/ralexstokes/ssz-rs/pull/161 (aligned with the author)

Here I add scaffolding for a Criterion benchmark.

Next I'll add better benchmark data. I'm considering either gettings txs from a random block or randomly generating tx data. Leaning towards random sampling. WDYT?

```
cargo bench
...
test result: ok. 0 passed; 0 failed; 94 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running benches/merkleization.rs (target/release/deps/merkleization-a419062d8ee9f395)
Benchmarking hash_tree_root: Collecting 100 samples in estimated 5.2192 s (116k iterations
hash_tree_root          time:   [44.761 µs 44.939 µs 45.163 µs]
                        change: [-3.7546% +0.0491% +3.8651%] (p = 0.98 > 0.05)
                        No change in performance detected.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) high mild
  6 (6.00%) high severe
```
