### PR TITLE
chore: bump bitvec and sha2 deps

### DIFF
--- a/ssz-rs/Cargo.toml
+++ b/ssz-rs/Cargo.toml
@@ -18,9 +18,9 @@ sha2-asm = ["sha2/asm"]
 serde = ["dep:serde", "alloy-primitives/serde"]
 
 [dependencies]
-bitvec = { version = "1.0.0", default-features = false, features = ["alloc"] }
+bitvec = { version = "1.0.1", default-features = false, features = ["alloc"] }
 ssz_rs_derive = { path = "../ssz-rs-derive", version = "0.9.0" }
-sha2 = { version = "0.9.8", default-features = false }
+sha2 = { version = "0.10.8", default-features = false }
 serde = { version = "1.0", default-features = false, features = [
     "alloc",
     "derive",


### PR DESCRIPTION
[bitvec 1.0.0](https://github.com/ferrilab/bitvec/blob/main/CHANGELOG.md#notes) introduced some perf regresions that are fixed in 1.0.1

[sha2 0.9.8](https://github.com/RustCrypto/hashes/blob/master/sha2/CHANGELOG.md#098-2021-09-09-yanked) is yanked. Not sure why.