### PR TITLE
Replace `Prove` trait with more generic `Visitable` trait, implement for all types, and rewrite prove in terms of it

### DIFF
--- a/ssz-rs-derive/src/lib.rs
+++ b/ssz-rs-derive/src/lib.rs
@@ -767,7 +767,7 @@ fn derive_visitable_impl(data: &Data, name: &Ident, generics: &Generics) -> Toke
                 #visit_element_impl
             }
 
-            fn element_count(&self) -> usize {
+            fn element_count() -> usize {
                 #element_count_impl
             }
         }

--- a/ssz-rs-derive/src/lib.rs
+++ b/ssz-rs-derive/src/lib.rs
@@ -115,7 +115,7 @@ fn derive_deserialize_impl(data: &Data, helper_attr: Option<&HelperAttr>) -> Tok
                             let result = <#field_type>::deserialize(&encoding)?;
                             Ok(Self(result))
                         }
-                    }
+                    };
                 }
                 _ => unimplemented!(
                     "this type of struct is currently not supported by this derive macro"
@@ -588,39 +588,16 @@ fn derive_generalized_indexable_impl(
     }
 }
 
-fn derive_prove_impl(data: &Data, name: &Ident, generics: &Generics) -> TokenStream {
+fn derive_chunkable_impl(data: &Data, name: &Ident, generics: &Generics) -> TokenStream {
     let (impl_generics, ty_generics, _) = generics.split_for_impl();
 
-    let (chunks_impl, prove_element_impl, decoration_impl) = match data {
+    let (chunks_impl, decoration_impl) = match data {
         Data::Struct(ref data) => match data.fields {
-            Fields::Named(ref fields) => {
-                let fields = &fields.named;
-                let field_count = fields.len();
-                let impl_by_field = fields.iter().enumerate().map(|(i, field)| {
-                    let field_name = field.ident.as_ref().expect("only named fields");
-                    quote! {
-                         #i => {
-                            let child = &self.#field_name;
-                            prover.compute_proof(child)
-                        }
-                    }
-                });
+            Fields::Named(ref _fields) => {
                 let chunks_impl = quote! {
                     self.assemble_chunks()
                 };
-
-                let prove_element_impl = quote! {
-                    if index >= #field_count {
-                        Err(MerkleizationError::InvalidInnerIndex)
-                    } else {
-                        match index {
-                            #(#impl_by_field)*
-                            _ => unreachable!("validated `index` to be within container type"),
-                        }
-                    }
-                };
-
-                (chunks_impl, prove_element_impl, None)
+                (chunks_impl, None)
             }
             Fields::Unnamed(..) => {
                 // NOTE: new type pattern, proxy to wrapped type...
@@ -628,33 +605,23 @@ fn derive_prove_impl(data: &Data, name: &Ident, generics: &Generics) -> TokenStr
                     self.0.chunks()
                 };
 
-                let prove_element_impl = quote! {
-                    self.0.prove_element(index, prover)
-                };
-
                 let decoration_impl = quote! {
                     fn decoration(&self) -> Option<usize> {
                         self.0.decoration()
                     }
                 };
-                (chunks_impl, prove_element_impl, Some(decoration_impl))
+                (chunks_impl, Some(decoration_impl))
             }
             Fields::Unit => unreachable!("validated to exclude this type"),
         },
         Data::Enum(ref data) => {
-            let variant_count = data.variants.len();
-
-            let implementations = data.variants.iter().enumerate().map(|(i, variant)| {
+            let decoration_by_variant = data.variants.iter().enumerate().map(|(i, variant)| {
                 let variant_name = &variant.ident;
                 match &variant.fields {
                     Fields::Unnamed(..) => {
-                        let prove_element_impl = quote! {
-                            Self::#variant_name(value) => prover.compute_proof(value),
-                        };
-                        let decoration_impl = quote! {
+                        quote! {
                             Self::#variant_name(_) => Some(#i),
-                        };
-                        (prove_element_impl, decoration_impl)
+                        }
                     }
                     Fields::Unit => {
                         // NOTE: this has already been validated to conform to:
@@ -662,33 +629,14 @@ fn derive_prove_impl(data: &Data, name: &Ident, generics: &Generics) -> TokenStr
                         if i != 0 || !is_valid_none_identifier(variant_name) {
                             panic!("internal validation inconsistency; check proc derive macro");
                         }
-                        (
-                            quote! {
-                                Self::None => {
-                                    let leaf = 0usize;
-                                    prover.compute_proof(&leaf)
-                                }
-                            },
-                            quote! {
-                                Self::None => Some(#i),
-                            },
-                        )
+                        quote! {
+                            Self::None => Some(#i),
+                        }
                     }
                     _ => unreachable!("other variants validated to not exist"),
                 }
             });
-            let (impl_by_variant, decoration_by_variant): (Vec<_>, Vec<_>) =
-                implementations.unzip();
 
-            let prove_element_impl = quote! {
-                if index >= #variant_count {
-                    Err(ssz_rs::MerkleizationError::InvalidInnerIndex)
-                } else {
-                    match self {
-                        #(#impl_by_variant)*
-                    }
-                }
-            };
             let chunks_impl = quote! {
                 self.assemble_chunks()
             };
@@ -699,26 +647,110 @@ fn derive_prove_impl(data: &Data, name: &Ident, generics: &Generics) -> TokenStr
                     }
                 }
             };
-            (chunks_impl, prove_element_impl, Some(decoration_impl))
+            (chunks_impl, Some(decoration_impl))
         }
         Data::Union(..) => unreachable!("data was already validated to exclude union types"),
     };
 
     quote! {
-        impl #impl_generics ssz_rs::Prove for #name #ty_generics {
+        impl #impl_generics ssz_rs::Chunkable for #name #ty_generics {
             fn chunks(&self) -> Result<Vec<u8>, ssz_rs::MerkleizationError> {
                 #chunks_impl
             }
 
-            fn prove_element(
+            #decoration_impl
+        }
+    }
+}
+
+fn derive_visitable_impl(data: &Data, name: &Ident, generics: &Generics) -> TokenStream {
+    let (impl_generics, ty_generics, _) = generics.split_for_impl();
+
+    let visit_element_impl = match data {
+        Data::Struct(ref data) => match data.fields {
+            Fields::Named(ref fields) => {
+                let fields = &fields.named;
+                let field_count = fields.len();
+                let impl_by_field = fields.iter().enumerate().map(|(i, field)| {
+                    let field_name = field.ident.as_ref().expect("only named fields");
+                    quote! {
+                         #i => {
+                            let child = &self.#field_name;
+                            visitor.visit(child)
+                        }
+                    }
+                });
+
+                quote! {
+                    if index >= #field_count {
+                        Err(ssz_rs::VisitorError::InvalidInnerIndex.into())
+                    } else {
+                        match index {
+                            #(#impl_by_field)*
+                            _ => unreachable!("validated `index` to be within container type"),
+                        }
+                    }
+                }
+            }
+            Fields::Unnamed(..) => {
+                // NOTE: new type pattern, proxy to wrapped type...
+                quote! {
+                    self.0.visit_element(index, visitor)
+                }
+            }
+            Fields::Unit => unreachable!("validated to exclude this type"),
+        },
+        Data::Enum(ref data) => {
+            let variant_count = data.variants.len();
+
+            let impl_by_variant = data.variants.iter().enumerate().map(|(i, variant)| {
+                let variant_name = &variant.ident;
+                match &variant.fields {
+                    Fields::Unnamed(..) => {
+                        quote! {
+                            Self::#variant_name(value) => visitor.visit(value),
+                        }
+                    }
+                    Fields::Unit => {
+                        // NOTE: this has already been validated to conform to:
+                        // first variant, and is `None` identifier
+                        if i != 0 || !is_valid_none_identifier(variant_name) {
+                            panic!("internal validation inconsistency; check proc derive macro");
+                        }
+
+                        quote! {
+                            Self::None => {
+                                let leaf = 0usize;
+                                visitor.visit(&leaf)
+                            }
+                        }
+                    }
+                    _ => unreachable!("other variants validated to not exist"),
+                }
+            });
+
+            quote! {
+                if index >= #variant_count {
+                    Err(ssz_rs::VisitorError::InvalidInnerIndex.into())
+                } else {
+                    match self {
+                        #(#impl_by_variant)*
+                    }
+                }
+            }
+        }
+        Data::Union(..) => unreachable!("data was already validated to exclude union types"),
+    };
+
+    quote! {
+        impl #impl_generics ssz_rs::Visitable for #name #ty_generics {
+            fn visit_element<V: ssz_rs::Visitor>(
                 &self,
                 index: usize,
-                prover: &mut ssz_rs::proofs::Prover,
-            ) -> Result<(), ssz_rs::MerkleizationError> {
-                #prove_element_impl
+                visitor: &mut V,
+            ) -> Result<(), V::Error> {
+                #visit_element_impl
             }
-
-            #decoration_impl
         }
     }
 }
@@ -976,9 +1008,9 @@ pub fn derive_generalized_indexable(input: proc_macro::TokenStream) -> proc_macr
     proc_macro::TokenStream::from(expansion)
 }
 
-/// Derive an implementation of the `Prove` trait to support Merkle proofs.
-#[proc_macro_derive(Prove)]
-pub fn derive_prove(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+/// Derive an implementation of the `Chunkable` trait to support Merkle proofs.
+#[proc_macro_derive(Chunkable)]
+pub fn derive_chunkable(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
 
     let data = &input.data;
@@ -986,7 +1018,21 @@ pub fn derive_prove(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let name = &input.ident;
     let generics = &input.generics;
 
-    let expansion = derive_prove_impl(data, name, generics);
+    let expansion = derive_chunkable_impl(data, name, generics);
+    proc_macro::TokenStream::from(expansion)
+}
+
+/// Derive an implementation of the `Visitable` trait to support Merkle proofs.
+#[proc_macro_derive(Visitable)]
+pub fn derive_visitable(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+
+    let data = &input.data;
+    validate_derive_input(data, &[]);
+    let name = &input.ident;
+    let generics = &input.generics;
+
+    let expansion = derive_visitable_impl(data, name, generics);
     proc_macro::TokenStream::from(expansion)
 }
 
@@ -1008,7 +1054,9 @@ pub fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 
     let generalized_indexable_impl = derive_generalized_indexable_impl(data, name, generics);
 
-    let prove_impl = derive_prove_impl(data, name, generics);
+    let chunkable_impl = derive_chunkable_impl(data, name, generics);
+
+    let visitable_impl = derive_visitable_impl(data, name, generics);
 
     let simple_serialize_impl = derive_simple_serialize_impl(name, generics);
 
@@ -1019,7 +1067,9 @@ pub fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 
         #generalized_indexable_impl
 
-        #prove_impl
+        #chunkable_impl
+
+        #visitable_impl
 
         #simple_serialize_impl
     };

--- a/ssz-rs-derive/src/lib.rs
+++ b/ssz-rs-derive/src/lib.rs
@@ -767,7 +767,7 @@ fn derive_visitable_impl(data: &Data, name: &Ident, generics: &Generics) -> Toke
                 #visit_element_impl
             }
 
-            fn element_count() -> usize {
+            fn element_count(&self) -> usize {
                 #element_count_impl
             }
         }

--- a/ssz-rs/src/array.rs
+++ b/ssz-rs/src/array.rs
@@ -130,7 +130,7 @@ where
         }
     }
 
-    fn element_count() -> usize {
+    fn element_count(&self) -> usize {
         N
     }
 }

--- a/ssz-rs/src/array.rs
+++ b/ssz-rs/src/array.rs
@@ -129,6 +129,10 @@ where
             visitor.visit(child)
         }
     }
+
+    fn element_count(&self) -> usize {
+        N
+    }
 }
 
 impl<T, const N: usize> Chunkable for [T; N]

--- a/ssz-rs/src/array.rs
+++ b/ssz-rs/src/array.rs
@@ -3,12 +3,12 @@ use crate::{
     error::{InstanceError, TypeError},
     lib::*,
     merkleization::{
-        elements_to_chunks, get_power_of_two_ceil, merkleize, pack,
-        proofs::{Prove, Prover},
+        elements_to_chunks, get_power_of_two_ceil, merkleize, pack, proofs::Chunkable,
         GeneralizedIndex, GeneralizedIndexable, HashTreeRoot, MerkleizationError, Node, Path,
         PathElement,
     },
     ser::{Serialize, SerializeError, Serializer},
+    visitor::{self, Visitable, Visitor},
     Serializable, SimpleSerialize,
 };
 
@@ -31,7 +31,7 @@ where
 {
     fn serialize(&self, buffer: &mut Vec<u8>) -> Result<usize, SerializeError> {
         if N == 0 {
-            return Err(TypeError::InvalidBound(N).into())
+            return Err(TypeError::InvalidBound(N).into());
         }
         let mut serializer = Serializer::default();
         for element in self {
@@ -47,7 +47,7 @@ where
 {
     fn deserialize(encoding: &[u8]) -> Result<Self, DeserializeError> {
         if N == 0 {
-            return Err(TypeError::InvalidBound(N).into())
+            return Err(TypeError::InvalidBound(N).into());
         }
 
         if !T::is_variable_size() {
@@ -56,13 +56,13 @@ where
                 return Err(DeserializeError::ExpectedFurtherInput {
                     provided: encoding.len(),
                     expected: expected_length,
-                })
+                });
             }
             if encoding.len() > expected_length {
                 return Err(DeserializeError::AdditionalInput {
                     provided: encoding.len(),
                     expected: expected_length,
-                })
+                });
             }
         }
         let elements = deserialize_homogeneous_composite(encoding)?;
@@ -102,7 +102,7 @@ where
             match next {
                 PathElement::Index(i) => {
                     if *i >= N {
-                        return Err(MerkleizationError::InvalidPathElement(next.clone()))
+                        return Err(MerkleizationError::InvalidPathElement(next.clone()));
                     }
                     let chunk_position = i * T::item_length() / 32;
                     let child =
@@ -117,7 +117,21 @@ where
     }
 }
 
-impl<T, const N: usize> Prove for [T; N]
+impl<T, const N: usize> Visitable for [T; N]
+where
+    T: SimpleSerialize + Visitable,
+{
+    fn visit_element<V: Visitor>(&self, index: usize, visitor: &mut V) -> Result<(), V::Error> {
+        if index >= N {
+            Err(visitor::VisitorError::InvalidInnerIndex.into())
+        } else {
+            let child = &self[index];
+            visitor.visit(child)
+        }
+    }
+}
+
+impl<T, const N: usize> Chunkable for [T; N]
 where
     T: SimpleSerialize,
 {
@@ -127,15 +141,6 @@ where
             elements_to_chunks(self.iter().enumerate(), count)
         } else {
             pack(self)
-        }
-    }
-
-    fn prove_element(&self, index: usize, prover: &mut Prover) -> Result<(), MerkleizationError> {
-        if index >= N {
-            Err(MerkleizationError::InvalidInnerIndex)
-        } else {
-            let child = &self[index];
-            prover.compute_proof(child)
         }
     }
 }

--- a/ssz-rs/src/array.rs
+++ b/ssz-rs/src/array.rs
@@ -130,7 +130,7 @@ where
         }
     }
 
-    fn element_count(&self) -> usize {
+    fn element_count() -> usize {
         N
     }
 }

--- a/ssz-rs/src/bitlist.rs
+++ b/ssz-rs/src/bitlist.rs
@@ -203,10 +203,10 @@ impl<const N: usize> GeneralizedIndexable for Bitlist<N> {
                         return Err(MerkleizationError::InvalidPathElement(next.clone()));
                     }
                     let chunk_position = i / 256;
-                    let child = parent
-                        * 2
-                        * get_power_of_two_ceil(<Self as GeneralizedIndexable>::chunk_count())
-                        + chunk_position;
+                    let child = parent *
+                        2 *
+                        get_power_of_two_ceil(<Self as GeneralizedIndexable>::chunk_count()) +
+                        chunk_position;
                     // NOTE: use `bool` as effective type of element
                     bool::compute_generalized_index(child, rest)
                 }

--- a/ssz-rs/src/bitvector.rs
+++ b/ssz-rs/src/bitvector.rs
@@ -3,11 +3,12 @@ use crate::{
     error::{Error, InstanceError, TypeError},
     lib::*,
     merkleization::{
-        get_power_of_two_ceil, merkleize, pack_bytes, proofs::Prove, GeneralizedIndex,
+        get_power_of_two_ceil, merkleize, pack_bytes, proofs::Chunkable, GeneralizedIndex,
         GeneralizedIndexable, HashTreeRoot, MerkleizationError, Node, Path, PathElement,
         BITS_PER_CHUNK,
     },
     ser::{Serialize, SerializeError},
+    visitor::Visitable,
     Serializable, SimpleSerialize,
 };
 #[cfg(feature = "serde")]
@@ -120,7 +121,7 @@ impl<const N: usize> Serializable for Bitvector<N> {
 impl<const N: usize> Serialize for Bitvector<N> {
     fn serialize(&self, buffer: &mut Vec<u8>) -> Result<usize, SerializeError> {
         if N == 0 {
-            return Err(TypeError::InvalidBound(N).into())
+            return Err(TypeError::InvalidBound(N).into());
         }
         let bytes_to_write = Self::size_hint();
         buffer.reserve(bytes_to_write);
@@ -134,7 +135,7 @@ impl<const N: usize> Serialize for Bitvector<N> {
 impl<const N: usize> Deserialize for Bitvector<N> {
     fn deserialize(encoding: &[u8]) -> Result<Self, DeserializeError> {
         if N == 0 {
-            return Err(TypeError::InvalidBound(N).into())
+            return Err(TypeError::InvalidBound(N).into());
         }
 
         let expected_length = byte_length(N);
@@ -142,13 +143,13 @@ impl<const N: usize> Deserialize for Bitvector<N> {
             return Err(DeserializeError::ExpectedFurtherInput {
                 provided: encoding.len(),
                 expected: expected_length,
-            })
+            });
         }
         if encoding.len() > expected_length {
             return Err(DeserializeError::AdditionalInput {
                 provided: encoding.len(),
                 expected: expected_length,
-            })
+            });
         }
 
         let mut result = Self::default();
@@ -160,7 +161,7 @@ impl<const N: usize> Deserialize for Bitvector<N> {
             let last_byte = encoding.last().unwrap();
             let remainder_bits = last_byte >> remainder_count;
             if remainder_bits != 0 {
-                return Err(DeserializeError::InvalidByte(*last_byte))
+                return Err(DeserializeError::InvalidByte(*last_byte));
             }
         }
         Ok(result)
@@ -187,12 +188,12 @@ impl<const N: usize> GeneralizedIndexable for Bitvector<N> {
             match next {
                 PathElement::Index(i) => {
                     if *i >= N {
-                        return Err(MerkleizationError::InvalidPathElement(next.clone()))
+                        return Err(MerkleizationError::InvalidPathElement(next.clone()));
                     }
                     let chunk_position = i / 256;
-                    let child = parent *
-                        get_power_of_two_ceil(<Self as GeneralizedIndexable>::chunk_count()) +
-                        chunk_position;
+                    let child = parent
+                        * get_power_of_two_ceil(<Self as GeneralizedIndexable>::chunk_count())
+                        + chunk_position;
                     // NOTE: use `bool` as effective type of element
                     bool::compute_generalized_index(child, rest)
                 }
@@ -204,7 +205,9 @@ impl<const N: usize> GeneralizedIndexable for Bitvector<N> {
     }
 }
 
-impl<const N: usize> Prove for Bitvector<N> {
+impl<const N: usize> Visitable for Bitvector<N> {}
+
+impl<const N: usize> Chunkable for Bitvector<N> {
     fn chunks(&self) -> Result<Vec<u8>, MerkleizationError> {
         self.pack_bits()
     }

--- a/ssz-rs/src/bitvector.rs
+++ b/ssz-rs/src/bitvector.rs
@@ -191,9 +191,9 @@ impl<const N: usize> GeneralizedIndexable for Bitvector<N> {
                         return Err(MerkleizationError::InvalidPathElement(next.clone()));
                     }
                     let chunk_position = i / 256;
-                    let child = parent
-                        * get_power_of_two_ceil(<Self as GeneralizedIndexable>::chunk_count())
-                        + chunk_position;
+                    let child = parent *
+                        get_power_of_two_ceil(<Self as GeneralizedIndexable>::chunk_count()) +
+                        chunk_position;
                     // NOTE: use `bool` as effective type of element
                     bool::compute_generalized_index(child, rest)
                 }

--- a/ssz-rs/src/boolean.rs
+++ b/ssz-rs/src/boolean.rs
@@ -2,10 +2,11 @@ use crate::{
     de::{Deserialize, DeserializeError},
     lib::*,
     merkleization::{
-        proofs::Prove, GeneralizedIndexable, HashTreeRoot, MerkleizationError, Node,
+        proofs::Chunkable, GeneralizedIndexable, HashTreeRoot, MerkleizationError, Node,
         BYTES_PER_CHUNK,
     },
     ser::{Serialize, SerializeError},
+    visitor::Visitable,
     Serializable, SimpleSerialize,
 };
 
@@ -62,7 +63,9 @@ impl GeneralizedIndexable for bool {
     }
 }
 
-impl Prove for bool {
+impl Visitable for bool {}
+
+impl Chunkable for bool {
     fn chunks(&self) -> Result<Vec<u8>, MerkleizationError> {
         let mut vec = vec![0u8; BYTES_PER_CHUNK];
         if *self {

--- a/ssz-rs/src/lib.rs
+++ b/ssz-rs/src/lib.rs
@@ -172,7 +172,7 @@ mod exports {
             multiproofs,
             proofs::{self, is_valid_merkle_branch, Chunkable, Prove},
             GeneralizedIndex, GeneralizedIndexable, HashTreeRoot, MerkleizationError, Node, Path,
-            PathElement,
+            PathElement, Tree,
         },
         ser::{Serialize, SerializeError},
         uint::U256,

--- a/ssz-rs/src/lib.rs
+++ b/ssz-rs/src/lib.rs
@@ -102,6 +102,7 @@ mod serde;
 mod uint;
 mod union;
 mod vector;
+mod visitor;
 
 mod lib {
     mod core {
@@ -154,7 +155,10 @@ pub trait Serializable: Serialize + Deserialize {
 /// `SimpleSerialize` is a trait for types conforming to the SSZ spec.
 /// These types can be encoded and decoded while also supporting the
 /// merkelization scheme of SSZ.
-pub trait SimpleSerialize: Serializable + HashTreeRoot + GeneralizedIndexable + Prove {}
+pub trait SimpleSerialize:
+    Serializable + HashTreeRoot + GeneralizedIndexable + Chunkable + Visitable
+{
+}
 
 mod exports {
     pub use crate::{
@@ -166,13 +170,14 @@ mod exports {
         merkleization::{
             generalized_index::default_generalized_index,
             multiproofs,
-            proofs::{self, is_valid_merkle_branch, Prove},
+            proofs::{self, is_valid_merkle_branch, Chunkable, Prove},
             GeneralizedIndex, GeneralizedIndexable, HashTreeRoot, MerkleizationError, Node, Path,
             PathElement,
         },
         ser::{Serialize, SerializeError},
         uint::U256,
         vector::Vector,
+        visitor::{Visitable, Visitor, VisitorError},
     };
 
     /// `serialize` is a convenience function for taking a value that
@@ -210,7 +215,7 @@ pub mod prelude {
     #[doc(hidden)]
     pub use crate as ssz_rs;
     pub use ssz_rs_derive::{
-        GeneralizedIndexable, HashTreeRoot, Prove, Serializable, SimpleSerialize,
+        Chunkable, GeneralizedIndexable, HashTreeRoot, Serializable, SimpleSerialize, Visitable,
     };
 }
 

--- a/ssz-rs/src/list.rs
+++ b/ssz-rs/src/list.rs
@@ -288,8 +288,8 @@ where
         }
     }
 
-    fn element_count() -> usize {
-        N
+    fn element_count(&self) -> usize {
+        self.len()
     }
 }
 

--- a/ssz-rs/src/list.rs
+++ b/ssz-rs/src/list.rs
@@ -288,7 +288,7 @@ where
         }
     }
 
-    fn element_count(&self) -> usize {
+    fn element_count() -> usize {
         N
     }
 }

--- a/ssz-rs/src/list.rs
+++ b/ssz-rs/src/list.rs
@@ -254,10 +254,10 @@ where
                         return Err(MerkleizationError::InvalidPathElement(next.clone()));
                     }
                     let chunk_position = i * T::item_length() / 32;
-                    let child = parent *
-                        2 *
-                        get_power_of_two_ceil(<Self as GeneralizedIndexable>::chunk_count()) +
-                        chunk_position;
+                    let child = parent
+                        * 2
+                        * get_power_of_two_ceil(<Self as GeneralizedIndexable>::chunk_count())
+                        + chunk_position;
                     T::compute_generalized_index(child, rest)
                 }
                 PathElement::Length => {
@@ -286,6 +286,10 @@ where
             let child = &self[index];
             visitor.visit(child)
         }
+    }
+
+    fn element_count(&self) -> usize {
+        N
     }
 }
 

--- a/ssz-rs/src/list.rs
+++ b/ssz-rs/src/list.rs
@@ -254,10 +254,10 @@ where
                         return Err(MerkleizationError::InvalidPathElement(next.clone()));
                     }
                     let chunk_position = i * T::item_length() / 32;
-                    let child = parent
-                        * 2
-                        * get_power_of_two_ceil(<Self as GeneralizedIndexable>::chunk_count())
-                        + chunk_position;
+                    let child = parent *
+                        2 *
+                        get_power_of_two_ceil(<Self as GeneralizedIndexable>::chunk_count()) +
+                        chunk_position;
                     T::compute_generalized_index(child, rest)
                 }
                 PathElement::Length => {

--- a/ssz-rs/src/merkleization/mod.rs
+++ b/ssz-rs/src/merkleization/mod.rs
@@ -4,7 +4,7 @@ pub mod multiproofs;
 mod node;
 pub mod proofs;
 
-use crate::{lib::*, ser::SerializeError};
+use crate::{lib::*, ser::SerializeError, visitor};
 pub use generalized_index::{
     get_power_of_two_ceil, GeneralizedIndex, GeneralizedIndexable, Path, PathElement,
 };
@@ -36,11 +36,19 @@ pub enum MerkleizationError {
     NoInnerElement,
     /// Attempt to turn an instance of a type in Merkle chunks when this is not supported
     NotChunkable,
+    /// Error encountered while traversing the SSZ type
+    Visitor(visitor::VisitorError),
 }
 
 impl From<SerializeError> for MerkleizationError {
     fn from(err: SerializeError) -> Self {
         MerkleizationError::SerializationError(err)
+    }
+}
+
+impl From<visitor::VisitorError> for MerkleizationError {
+    fn from(err: visitor::VisitorError) -> Self {
+        MerkleizationError::Visitor(err)
     }
 }
 
@@ -63,6 +71,7 @@ impl Display for MerkleizationError {
             Self::NotChunkable => {
                 write!(f, "requested to compute chunks for a type which does not support this")
             }
+            Self::Visitor(err) => write!(f, "visitor error: {err}"),
         }
     }
 }

--- a/ssz-rs/src/merkleization/node.rs
+++ b/ssz-rs/src/merkleization/node.rs
@@ -1,4 +1,4 @@
-use crate::{lib::*, merkleization::BYTES_PER_CHUNK, prelude::*};
+use crate::{lib::*, merkleization::BYTES_PER_CHUNK, prelude::*, visitor::Visitable};
 
 /// Represents a node in a Merkle tree as defined by the SSZ spec.
 pub type Node = alloy_primitives::B256;
@@ -16,13 +16,13 @@ impl Deserialize for Node {
             return Err(DeserializeError::ExpectedFurtherInput {
                 provided: encoding.len(),
                 expected: BYTES_PER_CHUNK,
-            })
+            });
         }
         if encoding.len() > BYTES_PER_CHUNK {
             return Err(DeserializeError::AdditionalInput {
                 provided: encoding.len(),
                 expected: BYTES_PER_CHUNK,
-            })
+            });
         }
 
         // SAFETY: index is safe because encoding.len() == byte_size; qed
@@ -53,7 +53,9 @@ impl HashTreeRoot for Node {
 
 impl GeneralizedIndexable for Node {}
 
-impl Prove for Node {
+impl Visitable for Node {}
+
+impl Chunkable for Node {
     fn chunks(&self) -> Result<Vec<u8>, MerkleizationError> {
         Ok(self.to_vec())
     }

--- a/ssz-rs/src/uint.rs
+++ b/ssz-rs/src/uint.rs
@@ -2,10 +2,11 @@ use crate::{
     de::{Deserialize, DeserializeError},
     lib::*,
     merkleization::{
-        pack_bytes, proofs::Prove, GeneralizedIndexable, HashTreeRoot, MerkleizationError, Node,
-        BYTES_PER_CHUNK,
+        pack_bytes, proofs::Chunkable, GeneralizedIndexable, HashTreeRoot, MerkleizationError,
+        Node, BYTES_PER_CHUNK,
     },
     ser::{Serialize, SerializeError},
+    visitor::Visitable,
     Serializable, SimpleSerialize, BITS_PER_BYTE,
 };
 
@@ -40,13 +41,13 @@ macro_rules! define_uint {
                     return Err(DeserializeError::ExpectedFurtherInput {
                         provided: encoding.len(),
                         expected: byte_size,
-                    })
+                    });
                 }
                 if encoding.len() > byte_size {
                     return Err(DeserializeError::AdditionalInput {
                         provided: encoding.len(),
                         expected: byte_size,
-                    })
+                    });
                 }
 
                 // SAFETY: index is safe because encoding.len() has been checked above; qed
@@ -72,7 +73,9 @@ macro_rules! define_uint {
             }
         }
 
-        impl Prove for $uint {
+        impl Visitable for $uint {}
+
+        impl Chunkable for $uint {
             fn chunks(&self) -> Result<Vec<u8>, MerkleizationError> {
                 let mut root = Vec::with_capacity(BYTES_PER_CHUNK);
                 let _ = self.serialize(&mut root)?;
@@ -120,13 +123,13 @@ impl Deserialize for U256 {
             return Err(DeserializeError::ExpectedFurtherInput {
                 provided: encoding.len(),
                 expected: U256_BYTE_COUNT,
-            })
+            });
         }
         if encoding.len() > U256_BYTE_COUNT {
             return Err(DeserializeError::AdditionalInput {
                 provided: encoding.len(),
                 expected: U256_BYTE_COUNT,
-            })
+            });
         }
 
         // SAFETY: index is safe because encoding.len() == byte_size; qed
@@ -153,7 +156,9 @@ impl GeneralizedIndexable for U256 {
     }
 }
 
-impl Prove for U256 {
+impl Visitable for U256 {}
+
+impl Chunkable for U256 {
     fn chunks(&self) -> Result<Vec<u8>, MerkleizationError> {
         Ok(self.as_le_bytes().to_vec())
     }

--- a/ssz-rs/src/union.rs
+++ b/ssz-rs/src/union.rs
@@ -146,7 +146,7 @@ where
         }
     }
 
-    fn element_count() -> usize {
+    fn element_count(&self) -> usize {
         2
     }
 }

--- a/ssz-rs/src/union.rs
+++ b/ssz-rs/src/union.rs
@@ -145,6 +145,10 @@ where
             }
         }
     }
+
+    fn element_count(&self) -> usize {
+        2
+    }
 }
 
 impl<T> Chunkable for Option<T>

--- a/ssz-rs/src/union.rs
+++ b/ssz-rs/src/union.rs
@@ -146,7 +146,7 @@ where
         }
     }
 
-    fn element_count(&self) -> usize {
+    fn element_count() -> usize {
         2
     }
 }

--- a/ssz-rs/src/vector.rs
+++ b/ssz-rs/src/vector.rs
@@ -279,7 +279,7 @@ where
         }
     }
 
-    fn element_count() -> usize {
+    fn element_count(&self) -> usize {
         N
     }
 }

--- a/ssz-rs/src/vector.rs
+++ b/ssz-rs/src/vector.rs
@@ -279,7 +279,7 @@ where
         }
     }
 
-    fn element_count(&self) -> usize {
+    fn element_count() -> usize {
         N
     }
 }

--- a/ssz-rs/src/vector.rs
+++ b/ssz-rs/src/vector.rs
@@ -278,6 +278,10 @@ where
             visitor.visit(child)
         }
     }
+
+    fn element_count(&self) -> usize {
+        N
+    }
 }
 
 impl<T, const N: usize> Chunkable for Vector<T, N>

--- a/ssz-rs/src/visitor.rs
+++ b/ssz-rs/src/visitor.rs
@@ -22,7 +22,8 @@ impl Display for VisitorError {
 }
 
 /// A trait for types that can be visited by a `Visitor`.
-/// All types that implement SimpleSerialize are visitable which is how proving and other algorithms are implemented
+/// All types that implement SimpleSerialize are visitable which is how proving and other algorithms
+/// are implemented
 pub trait Visitable {
     fn visit_element<V: Visitor>(&self, _index: usize, _visitor: &mut V) -> Result<(), V::Error> {
         Err(VisitorError::NoInnerElement.into())
@@ -32,7 +33,8 @@ pub trait Visitable {
 /// A trait for implementing the visitor pattern to traverse the SSZ data structures
 ///
 /// Examples of visitors are the Prover for generating SSZ Merkle proofs.
-/// Crate consumers can implement their own visitors to add diffent algorithms for generating proofs or other behaviour
+/// Crate consumers can implement their own visitors to add diffent algorithms for generating proofs
+/// or other behaviour
 pub trait Visitor: Sized {
     type Error: From<VisitorError>;
 

--- a/ssz-rs/src/visitor.rs
+++ b/ssz-rs/src/visitor.rs
@@ -29,7 +29,7 @@ pub trait Visitable {
         Err(VisitorError::NoInnerElement.into())
     }
 
-    fn element_count(&self) -> usize {
+    fn element_count() -> usize {
         0
     }
 }

--- a/ssz-rs/src/visitor.rs
+++ b/ssz-rs/src/visitor.rs
@@ -1,0 +1,43 @@
+use crate::SimpleSerialize;
+use std::fmt::{self, Display, Formatter};
+
+#[derive(Debug)]
+pub enum VisitorError {
+    NoInnerElement,
+    InvalidInnerIndex,
+}
+
+impl Display for VisitorError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NoInnerElement => {
+                write!(f, "requested to visit inner element which does not exist for this type")
+            }
+            Self::InvalidInnerIndex => write!(
+                f,
+                "requested to visit inner element outside the bounds of what this type supports"
+            ),
+        }
+    }
+}
+
+/// A trait for types that can be visited by a `Visitor`.
+/// All types that implement SimpleSerialize are visitable which is how proving and other algorithms are implemented
+pub trait Visitable {
+    fn visit_element<V: Visitor>(&self, _index: usize, _visitor: &mut V) -> Result<(), V::Error> {
+        Err(VisitorError::NoInnerElement.into())
+    }
+}
+
+/// A trait for implementing the visitor pattern to traverse the SSZ data structures
+///
+/// Examples of visitors are the Prover for generating SSZ Merkle proofs.
+/// Crate consumers can implement their own visitors to add diffent algorithms for generating proofs or other behaviour
+pub trait Visitor: Sized {
+    type Error: From<VisitorError>;
+
+    fn visit<T: SimpleSerialize + Visitable + ?Sized>(
+        &mut self,
+        element: &T,
+    ) -> Result<(), Self::Error>;
+}

--- a/ssz-rs/src/visitor.rs
+++ b/ssz-rs/src/visitor.rs
@@ -28,6 +28,10 @@ pub trait Visitable {
     fn visit_element<V: Visitor>(&self, _index: usize, _visitor: &mut V) -> Result<(), V::Error> {
         Err(VisitorError::NoInnerElement.into())
     }
+
+    fn element_count(&self) -> usize {
+        0
+    }
 }
 
 /// A trait for implementing the visitor pattern to traverse the SSZ data structures

--- a/ssz-rs/src/visitor.rs
+++ b/ssz-rs/src/visitor.rs
@@ -29,7 +29,7 @@ pub trait Visitable {
         Err(VisitorError::NoInnerElement.into())
     }
 
-    fn element_count() -> usize {
+    fn element_count(&self) -> usize {
         0
     }
 }


### PR DESCRIPTION
This crate has a forking issue. Many useful additions are scattered across over 40 forks and to me this suggests that the underlying API is not flexible enough to allow consumers to do what they want to do.

This PR aims to fix that once and for all so that a single version of `ssz_rs` can stabilize while new features can continue to be added in their own separate crates that work together with this one.

## Motivation

Features missing from this crate but implemented in forks include:
- Merkle proof building with caching
- Support different hash types
- Memory efficient proof building using precomputed zero nodes
- Merkle multiproofs
- Compact multiproofs

One operation that is common to all these algorithms is the idea of visiting the different containers that make up a composite SSZ container.

## Implementation

This PR introduces a generic `Visitable` trait 

```rust
trait Visitable {
    fn visit_element<V: Visitor>(&self, _index: usize, _visitor: &mut V) -> Result<(), V::Error>;
}
```

that is implemented by all primitives and containers via the derive macros. 

The above algorithms and more can be implemented by writing a custom type that implements the `Visitor` trait

```rust
trait Visitor: Sized {
    type Error: From<VisitorError>;

    fn visit<T: SimpleSerialize + Visitable + ?Sized>(
        &mut self,
        element: &T,
    ) -> Result<(), Self::Error>;
}
```

It also adds a new trait `Chunkable` also implemented for all primitives and containers that allows Visitor developers to access the underlying leaves of the subtree for each subcontainer. 

For example in this PR the `Prover` implementation is rewritten as a visitor that consumes chunks. 
https://github.com/willemolding/ssz-rs/blob/c1b956fe9d4dafc4309bcda118a6c6489a6c9064/ssz-rs/src/merkleization/proofs.rs#L75

This new API should make it easy for developers who want to implement new algorithms (or variations) that operate over the SSZ data structures in their own crates

## Changes

- Add `Visitable`, `Visitor`, and `Chunkable` traits
- Add implementations of `Visitable` and `Chunkable` for all primitive types
- Add derive implementations of `Visitable` and `Chunkable` via derive macros
- Reimplement `Prover` in terms of the above traits
- fmt and clippy modified files

